### PR TITLE
chore(package): mv externals to devDependencies

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -31,18 +31,18 @@
     "postpublish": "node scripts/restore-package.js"
   },
   "dependencies": {
-    "@tanstack/react-virtual": "^3.13.8",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "@tanstack/react-virtual": "^3.13.8"
   },
   "devDependencies": {
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "tsup": "^8.4.0",
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "react": ">=16 || >=17 || >= 18 || >= 19",
-    "react-dom": ">=16 || >=17 || >= 18 || >=19"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,12 +96,6 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.13.8
         version: 3.13.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react:
-        specifier: 'catalog:'
-        version: 19.1.0
-      react-dom:
-        specifier: 'catalog:'
-        version: 19.1.0(react@19.1.0)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -109,6 +103,12 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.1.5(@types/react@19.1.4)
+      react:
+        specifier: 'catalog:'
+        version: 19.1.0
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.1.0(react@19.1.0)
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.7.1)


### PR DESCRIPTION
externals are not shipped through bundle, which is desirable to be set as devDependencies