### PR TITLE
fix: react compiler, rsc, and hooks-lint compliance

### DIFF
--- a/.changeset/react-compliance.md
+++ b/.changeset/react-compliance.md
@@ -1,0 +1,5 @@
+---
+'react-virtual-masonry': patch
+---
+
+React ecosystem compliance: emit compiler-runtime imports that work on React 18 (`react-compiler-runtime` polyfill instead of React 19-only `react/compiler-runtime`), add a `'use client'` directive for React Server Components consumers, and stop reading refs during render in `useMasonry` (react-hooks v7 `refs` rule / concurrent-rendering safety).

--- a/package/src/hooks/useMasonry.ts
+++ b/package/src/hooks/useMasonry.ts
@@ -8,7 +8,9 @@ const DEFAULT_LANES = 4;
 const DEFAULT_OVERSCAN = 3;
 const DEFAULT_GUTTER = 20;
 
-/** SSR rendering configuration. Pass to opt into server-rendered positioned items. */
+/** SSR rendering configuration. Pass to opt into server-rendered positioned items.
+ *  Server-side layout cost scales with `data.length`, not `itemCount` — lane
+ *  assignment is order-dependent, so the whole list is laid out per request. */
 export interface SSRConfig {
   /** Number of items to render in server HTML. */
   itemCount: number;
@@ -72,14 +74,9 @@ export interface UseMasonryReturn {
   items: VirtualItem[];
   /** Current lane count — `--lanes` post-mount, fallback pre-mount. */
   lanes: number;
-  /**
-   * Underlying TanStack virtualizer (escape hatch for `scrollToIndex` etc.).
-   * Its identity is stable while its internals mutate — in a React
-   * Compiler–optimized component, values derived from it during render
-   * (`getVirtualItems()`, `getTotalSize()`, …) get cached stale. Prefer the
-   * `items` / `lanes` / `gridProps` returns; if you must derive, opt that
-   * component out with `'use no memo'`.
-   */
+  /** Underlying TanStack virtualizer (escape hatch for `scrollToIndex` etc.).
+   *  Stable identity + mutable internals — deriving render values from it in a
+   *  compiled component caches stale. Prefer `items`/`lanes`, or `'use no memo'`. */
   virtualizer: Virtualizer<Window, Element>;
 }
 
@@ -107,17 +104,14 @@ export function useMasonry<Data>({
 
   const gridRef = useRef<HTMLDivElement>(null);
 
-  // Clamped to >= 1 — lane math divides by n, so a user-supplied 0/negative
-  // `ssr.lanes` would emit Infinity/NaN CSS.
+  // Clamp to >= 1 — lane math divides by n; 0/negative would emit Infinity/NaN CSS.
   const lanes = useCSSLaneCount(gridRef, {
     fallback: Math.max(1, ssr?.lanes ?? DEFAULT_LANES),
   });
 
   const scrollMargin = useOffsetTop(gridRef, { fallback: ssr?.scrollMargin ?? 0 });
 
-  // Explicit mount signal instead of reading `gridRef.current` during render —
-  // ref reads in render are impure (react-hooks v7 `refs` rule) and unsafe
-  // under concurrent rendering.
+  // Explicit mount signal — reading `gridRef.current` during render is impure.
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
@@ -132,8 +126,7 @@ export function useMasonry<Data>({
   });
 
   // When no visible range yet (server, or client pre-effect), slice the cache
-  // for SSR rendering. Gated on `mounted` so a transient empty range post-mount
-  // never falls back to the top-of-list slice.
+  // for SSR rendering. The `mounted` gate keeps post-mount empty ranges empty.
   const visibleItems = virtualizer.getVirtualItems();
   const items =
     visibleItems.length === 0 && ssr && !mounted

--- a/package/src/hooks/useMasonry.ts
+++ b/package/src/hooks/useMasonry.ts
@@ -1,7 +1,8 @@
-import { CSSProperties, RefObject, useRef } from 'react';
+import { CSSProperties, RefObject, useEffect, useRef, useState } from 'react';
 import { useWindowVirtualizer, type VirtualItem, type Virtualizer } from '@tanstack/react-virtual';
 
 import { useCSSLaneCount } from './useCSSLaneCount';
+import { useOffsetTop } from './useOffsetTop';
 
 const DEFAULT_LANES = 4;
 const DEFAULT_OVERSCAN = 3;
@@ -71,7 +72,14 @@ export interface UseMasonryReturn {
   items: VirtualItem[];
   /** Current lane count — `--lanes` post-mount, fallback pre-mount. */
   lanes: number;
-  /** Underlying TanStack virtualizer (escape hatch for `scrollToIndex` etc.). */
+  /**
+   * Underlying TanStack virtualizer (escape hatch for `scrollToIndex` etc.).
+   * Its identity is stable while its internals mutate — in a React
+   * Compiler–optimized component, values derived from it during render
+   * (`getVirtualItems()`, `getTotalSize()`, …) get cached stale. Prefer the
+   * `items` / `lanes` / `gridProps` returns; if you must derive, opt that
+   * component out with `'use no memo'`.
+   */
   virtualizer: Virtualizer<Window, Element>;
 }
 
@@ -105,22 +113,30 @@ export function useMasonry<Data>({
     fallback: Math.max(1, ssr?.lanes ?? DEFAULT_LANES),
   });
 
+  const scrollMargin = useOffsetTop(gridRef, { fallback: ssr?.scrollMargin ?? 0 });
+
+  // Explicit mount signal instead of reading `gridRef.current` during render —
+  // ref reads in render are impure (react-hooks v7 `refs` rule) and unsafe
+  // under concurrent rendering.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   const virtualizer = useWindowVirtualizer({
     count: data.length,
     estimateSize: estimateSize ?? (() => 0),
     overscan,
     lanes,
-    scrollMargin: gridRef.current?.offsetTop ?? ssr?.scrollMargin ?? 0,
+    scrollMargin,
     gap: gutter,
     laneAssignmentMode: 'measured',
   });
 
   // When no visible range yet (server, or client pre-effect), slice the cache
-  // for SSR rendering. Gated on the ref so a transient empty range post-mount
+  // for SSR rendering. Gated on `mounted` so a transient empty range post-mount
   // never falls back to the top-of-list slice.
   const visibleItems = virtualizer.getVirtualItems();
   const items =
-    visibleItems.length === 0 && ssr && !gridRef.current
+    visibleItems.length === 0 && ssr && !mounted
       ? virtualizer.measurementsCache.slice(0, ssr.itemCount)
       : visibleItems;
 

--- a/package/src/hooks/useOffsetTop.test.ts
+++ b/package/src/hooks/useOffsetTop.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
+import { createElement } from 'react';
+
+import { useOffsetTop } from './useOffsetTop';
+
+type ROCallback = (entries: ResizeObserverEntry[]) => void;
+
+class SyncResizeObserver {
+  private callback: ROCallback;
+  constructor(callback: ROCallback) {
+    this.callback = callback;
+  }
+  observe(target: Element) {
+    // Fire synchronously so the snapshot is promoted before assertions run.
+    this.callback([{ target } as ResizeObserverEntry]);
+  }
+  disconnect() {}
+}
+
+describe('useOffsetTop', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', SyncResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('SSR snapshot returns fallback', () => {
+    let captured: number | undefined;
+
+    function TestComponent() {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      captured = useOffsetTop({ current: null }, { fallback: 120 });
+      return null;
+    }
+
+    renderToString(createElement(TestComponent));
+    expect(captured).toBe(120);
+  });
+
+  it('returns fallback when ref is null (pre-mount)', () => {
+    const ref = { current: null };
+    const { result } = renderHook(() => useOffsetTop(ref, { fallback: 80 }));
+    expect(result.current).toBe(80);
+  });
+
+  it('reads offsetTop from the element after mount', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    // happy-dom has no layout — stub the resolved value.
+    Object.defineProperty(div, 'offsetTop', { value: 240 });
+
+    const ref = { current: div };
+    const { result } = renderHook(() => useOffsetTop(ref, { fallback: 80 }));
+
+    expect(result.current).toBe(240);
+
+    document.body.removeChild(div);
+  });
+});

--- a/package/src/hooks/useOffsetTop.ts
+++ b/package/src/hooks/useOffsetTop.ts
@@ -1,17 +1,13 @@
 import { RefObject, useCallback, useSyncExternalStore } from 'react';
 
 interface UseOffsetTopOptions {
-  /**
-   * Value returned during SSR and before the element mounts. Should match the
-   * distance from document top assumed by the SSR HTML.
-   */
+  /** Value returned during SSR and before the element mounts. */
   fallback: number;
 }
 
 /**
- * Reads `offsetTop` from `elementRef` without touching `ref.current` during
- * render — the value lives in a `useSyncExternalStore` snapshot, re-read on
- * every render and on element resize via `ResizeObserver`.
+ * Reads `offsetTop` from `elementRef` as a `useSyncExternalStore` snapshot
+ * (re-read every render, refreshed on element resize) — no ref reads in render.
  *
  * - SSR / pre-mount: returns `fallback`.
  * - Post-mount: returns the layout-resolved `offsetTop`.

--- a/package/src/hooks/useOffsetTop.ts
+++ b/package/src/hooks/useOffsetTop.ts
@@ -1,0 +1,44 @@
+import { RefObject, useCallback, useSyncExternalStore } from 'react';
+
+interface UseOffsetTopOptions {
+  /**
+   * Value returned during SSR and before the element mounts. Should match the
+   * distance from document top assumed by the SSR HTML.
+   */
+  fallback: number;
+}
+
+/**
+ * Reads `offsetTop` from `elementRef` without touching `ref.current` during
+ * render — the value lives in a `useSyncExternalStore` snapshot, re-read on
+ * every render and on element resize via `ResizeObserver`.
+ *
+ * - SSR / pre-mount: returns `fallback`.
+ * - Post-mount: returns the layout-resolved `offsetTop`.
+ */
+export const useOffsetTop = (
+  elementRef: RefObject<HTMLElement | null>,
+  { fallback }: UseOffsetTopOptions
+): number => {
+  // ResizeObserver fires once in a microtask on `observe()` — that initial pulse
+  // promotes the snapshot from `fallback` to the layout-resolved value.
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const el = elementRef.current;
+      if (!el || typeof ResizeObserver === 'undefined') return () => {};
+      const observer = new ResizeObserver(onStoreChange);
+      observer.observe(el);
+      return () => observer.disconnect();
+    },
+    [elementRef]
+  );
+
+  const getSnapshot = useCallback((): number => {
+    const el = elementRef.current;
+    return el ? el.offsetTop : fallback;
+  }, [elementRef, fallback]);
+
+  const getServerSnapshot = useCallback(() => fallback, [fallback]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+};

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export * from './Masonry';
 
 export { useMasonry } from './hooks/useMasonry';

--- a/package/tsdown.config.ts
+++ b/package/tsdown.config.ts
@@ -20,9 +20,8 @@ export default defineConfig({
         sourceType: 'module',
         plugins: ['jsx', 'typescript'],
       },
-      // target '18': emit imports from the react-compiler-runtime polyfill
-      // (declared as a dependency) instead of react/compiler-runtime, which
-      // only exists in React 19 — peerDependencies allow ^18.
+      // target '18' → react-compiler-runtime polyfill imports; react/compiler-runtime
+      // is React 19-only and peerDependencies allow ^18.
       plugins: [['babel-plugin-react-compiler', { target: '18' }]],
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
     }),

--- a/package/tsdown.config.ts
+++ b/package/tsdown.config.ts
@@ -20,7 +20,10 @@ export default defineConfig({
         sourceType: 'module',
         plugins: ['jsx', 'typescript'],
       },
-      plugins: ['babel-plugin-react-compiler'],
+      // target '18': emit imports from the react-compiler-runtime polyfill
+      // (declared as a dependency) instead of react/compiler-runtime, which
+      // only exists in React 19 — peerDependencies allow ^18.
+      plugins: [['babel-plugin-react-compiler', { target: '18' }]],
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
     }),
   ],


### PR DESCRIPTION
- build: target react-compiler-runtime polyfill instead of React 19-only react/compiler-runtime — peerDependencies allow ^18
- add 'use client' so RSC consumers get a proper client boundary
- useMasonry: stop reading gridRef.current during render; scrollMargin comes from a useSyncExternalStore-backed useOffsetTop and the SSR fallback gate from an explicit mounted state
- document the compiler hazard on the returned virtualizer escape hatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with React 18 and React Server Components.
  * Added more reliable layout measurement behavior for masonry content.

* **Bug Fixes**
  * Fixed rendering issues caused by reading element refs during render.
  * Improved server-side and initial client-side fallback behavior so layouts load more consistently.
  * Updated offset calculations to respond better to layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->