### PR TITLE
fix: refresh scrollMargin on ancestor layout shifts

### DIFF
--- a/.changeset/stale-scroll-margin.md
+++ b/.changeset/stale-scroll-margin.md
@@ -1,0 +1,5 @@
+---
+'react-virtual-masonry': patch
+---
+
+Keep `scrollMargin` fresh when content above the grid changes height: `useOffsetTop` also observes the document body, so ancestor layout shifts that move `offsetTop` without resizing the grid no longer leave the virtualizer's scroll mapping stale.

--- a/package/src/hooks/useOffsetTop.test.ts
+++ b/package/src/hooks/useOffsetTop.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { renderToString } from 'react-dom/server';
 import { createElement } from 'react';
 
@@ -45,6 +45,51 @@ describe('useOffsetTop', () => {
     const ref = { current: null };
     const { result } = renderHook(() => useOffsetTop(ref, { fallback: 80 }));
     expect(result.current).toBe(80);
+  });
+
+  // Ancestor layout shift: content above the element changes height, so
+  // `offsetTop` moves while the element itself never resizes. Body height
+  // does change in that scenario — the subscription must catch it there.
+  it('refreshes when the body resizes without the element resizing', () => {
+    class ControlledResizeObserver {
+      static all: ControlledResizeObserver[] = [];
+      private readonly callback: ROCallback;
+      private readonly targets = new Set<Element>();
+      constructor(callback: ROCallback) {
+        this.callback = callback;
+        ControlledResizeObserver.all.push(this);
+      }
+      observe(target: Element) {
+        this.targets.add(target);
+      }
+      disconnect() {
+        this.targets.clear();
+      }
+      static fire(target: Element) {
+        for (const observer of ControlledResizeObserver.all) {
+          if (observer.targets.has(target)) {
+            observer.callback([{ target } as ResizeObserverEntry]);
+          }
+        }
+      }
+    }
+    vi.stubGlobal('ResizeObserver', ControlledResizeObserver);
+
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    let offsetTop = 100;
+    Object.defineProperty(div, 'offsetTop', { get: () => offsetTop });
+
+    const ref = { current: div };
+    const { result } = renderHook(() => useOffsetTop(ref, { fallback: 0 }));
+    expect(result.current).toBe(100);
+
+    // Content above grows: offsetTop moves, only the body resize fires.
+    offsetTop = 300;
+    act(() => ControlledResizeObserver.fire(document.body));
+    expect(result.current).toBe(300);
+
+    document.body.removeChild(div);
   });
 
   it('reads offsetTop from the element after mount', () => {

--- a/package/src/hooks/useOffsetTop.ts
+++ b/package/src/hooks/useOffsetTop.ts
@@ -24,6 +24,10 @@ export const useOffsetTop = (
       if (!el || typeof ResizeObserver === 'undefined') return () => {};
       const observer = new ResizeObserver(onStoreChange);
       observer.observe(el);
+      // Ancestor layout shifts move `offsetTop` without resizing the element;
+      // content-above changes almost always resize the body, so watch it too.
+      const body = el.ownerDocument?.body;
+      if (body) observer.observe(body);
       return () => observer.disconnect();
     },
     [elementRef]


### PR DESCRIPTION
ResizeObserver on the grid alone misses content-above height changes that move offsetTop without resizing the grid, leaving the window virtualizer's scroll mapping stale. 

Observe the document body too — those shifts almost always resize it. Repro covered by a regression test (offsetTop moves, only body fires).