### PR TITLE
fix: add workaround for gutter to update vertical gap

### DIFF
--- a/.changeset/purple-seas-thank.md
+++ b/.changeset/purple-seas-thank.md
@@ -1,0 +1,5 @@
+---
+'react-virtual-masonry': patch
+---
+
+Added workaround for gutter to update vertical gap

--- a/package/src/hooks/useMasonry.test.tsx
+++ b/package/src/hooks/useMasonry.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useMasonry } from './useMasonry';
+
+const measureSpy = vi.fn();
+
+vi.mock('@tanstack/react-virtual', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@tanstack/react-virtual')>();
+  return {
+    ...mod,
+    useWindowVirtualizer: ((options: Parameters<typeof mod.useWindowVirtualizer>[0]) => {
+      const virtualizer = mod.useWindowVirtualizer(options);
+      if (virtualizer.measure !== measureSpy) {
+        measureSpy.mockImplementation(virtualizer.measure.bind(virtualizer));
+        virtualizer.measure = measureSpy;
+      }
+      return virtualizer;
+    }) as typeof mod.useWindowVirtualizer,
+  };
+});
+
+describe('useMasonry gutter workaround', () => {
+  // https://github.com/TanStack/virtual/issues/1222
+  it('remeasures when gutter changes, and only then', () => {
+    const data = [100, 200, 300, 400];
+    const { rerender } = renderHook(
+      ({ gutter }) => useMasonry({ data, estimateSize: (i) => data[i], gutter }),
+      { initialProps: { gutter: 20 } }
+    );
+
+    measureSpy.mockClear();
+
+    rerender({ gutter: 20 });
+    expect(measureSpy).not.toHaveBeenCalled();
+
+    rerender({ gutter: 40 });
+    expect(measureSpy).toHaveBeenCalledTimes(1);
+
+    rerender({ gutter: 40 });
+    expect(measureSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/package/src/hooks/useMasonry.ts
+++ b/package/src/hooks/useMasonry.ts
@@ -125,6 +125,16 @@ export function useMasonry<Data>({
     laneAssignmentMode: 'measured',
   });
 
+  // Workaround: gap changes don't invalidate virtual-core's measurement cache.
+  // https://github.com/TanStack/virtual/issues/1222
+  const prevGutter = useRef(gutter);
+  useEffect(() => {
+    if (prevGutter.current !== gutter) {
+      prevGutter.current = gutter;
+      virtualizer.measure();
+    }
+  }, [gutter, virtualizer]);
+
   // When no visible range yet (server, or client pre-effect), slice the cache
   // for SSR rendering. The `mounted` gate keeps post-mount empty ranges empty.
   const visibleItems = virtualizer.getVirtualItems();


### PR DESCRIPTION
Dynamic `gutter` changes were not applied — virtual-core doesn't invalidate its measurement cache when `gap` changes (TanStack/virtual#1222).

Workaround: call `virtualizer.measure()` when `gutter` changes, forcing a re-layout. Covered by a test asserting it fires only on actual gutter changes.

Revert once the upstream fix lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed masonry layouts so spacing updates correctly when the gap between items changes.
  * Improved layout recalculation to avoid stale measurements after gutter changes.

* **Tests**
  * Added coverage to verify the layout re-measures once when spacing changes and does not remeasure unnecessarily when it stays the same.

* **Chores**
  * Added a patch release note for the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->