### PR TITLE
feat: promote scrollToIndex to a first-class useMasonry API

### DIFF
--- a/.changeset/scroll-to-index.md
+++ b/.changeset/scroll-to-index.md
@@ -1,0 +1,5 @@
+---
+'react-virtual-masonry': minor
+---
+
+Add first-class `scrollToIndex(index, options?)` to `useMasonry`. It's also reachable from the `<Masonry>` component via a `ref` typed `MasonryHandle` (exposing `scrollToIndex` and the `virtualizer` escape hatch), so imperative control no longer requires composing the hook.

--- a/docs/src/pages/docs/api/masonry.mdx
+++ b/docs/src/pages/docs/api/masonry.mdx
@@ -92,6 +92,35 @@ Instance-specific selector for when multiple grids need different styling. Most 
 
 Merged after the library's grid styles. Do not override `height`, `width`, or `position` — the layout depends on them.
 
+## Imperative Handle
+
+You don't have to drop to [`useMasonry`](/docs/api/use-masonry) for imperative control. Pass a `ref` typed `MasonryHandle` to reach `scrollToIndex` (and the `virtualizer` escape hatch) from the component:
+
+```tsx twoslash
+import { useRef } from 'react';
+import { Masonry, type MasonryHandle } from 'react-virtual-masonry';
+
+const DATA = [200, 600, 200, 400, 100, 600, 200, 400];
+
+function App() {
+  const ref = useRef<MasonryHandle>(null);
+
+  return (
+    <>
+      <button onClick={() => ref.current?.scrollToIndex(5, { align: 'center' })}>Jump to 5</button>
+      <Masonry
+        ref={ref}
+        data={DATA}
+        estimateSize={(i) => DATA[i]}
+        renderItem={({ item, index }) => <div style={{ height: item }}>{index}</div>}
+      />
+    </>
+  );
+}
+```
+
+`MasonryHandle` exposes `scrollToIndex` (see [`useMasonry › scrollToIndex`](/docs/api/use-masonry#scrolltoindex) for its accuracy notes) and `virtualizer`. For a fully custom element structure, compose the hook directly instead.
+
 ## Styling Hooks
 
 The rendered markup exposes stable selectors:

--- a/docs/src/pages/docs/api/use-masonry.mdx
+++ b/docs/src/pages/docs/api/use-masonry.mdx
@@ -98,10 +98,46 @@ Current lane count — resolved from the `--lanes` CSS custom property post-moun
 
 - **Type:** `Virtualizer<Window, Element>`
 
-The underlying TanStack virtualizer — an escape hatch for imperative APIs like `scrollToIndex`.
+The underlying TanStack virtualizer — an escape hatch for imperative APIs beyond `scrollToIndex` (e.g. `scrollToOffset`, `measure`).
 
 :::warning
 The virtualizer has a stable identity with mutable internals. Deriving render values from it inside a React-Compiler-compiled component caches stale results — prefer `items` / `lanes`, or opt out with `'use no memo'`.
+:::
+
+### scrollToIndex
+
+- **Type:** `(index: number, options?: ScrollToOptions) => void`
+
+Scrolls so `index` is positioned per `options.align` (default `'auto'`: nearest edge, no-op if already visible). Referentially stable across renders — safe to pass in an effect's dependency array. A thin forward to TanStack Virtual's own method — `options` is its [`ScrollToOptions`](https://tanstack.com/virtual/latest/docs/api/virtualizer#scrolltoindex) (`align`: `'start' | 'center' | 'end' | 'auto'`, `behavior`: `'auto' | 'smooth'`).
+
+```tsx twoslash
+import { useMasonry } from 'react-virtual-masonry';
+
+const DATA = [200, 600, 200, 400, 100, 600, 200, 400, 100, 600];
+
+function App() {
+  const { gridProps, getItemProps, items, scrollToIndex } = useMasonry({
+    data: DATA,
+    estimateSize: () => 400,
+  });
+
+  return (
+    <>
+      <button onClick={() => scrollToIndex(7, { align: 'center' })}>Jump to item 7</button>
+      <section {...gridProps}>
+        {items.map((item) => (
+          <article key={item.key} {...getItemProps(item)}>
+            <div style={{ height: DATA[item.index] }}>{item.index}</div>
+          </article>
+        ))}
+      </section>
+    </>
+  );
+}
+```
+
+:::warning
+Accuracy is bounded by `estimateSize`: rows before `index` that have never been rendered contribute their _estimated_ size to the target offset, so a cold jump to a far index can land off-target. The error grows roughly as `Δ × (index / lanes)` px (`Δ` = how far `estimateSize` is from the real mean height) — the fix is a closer `estimateSize`, not repeated calls. A non-constant `estimateSize`'s effect on accuracy/lane balance, and interaction with scroll restoration, are uncharacterized.
 :::
 
 ## Selector Contract

--- a/package/src/Masonry/index.test.tsx
+++ b/package/src/Masonry/index.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRef } from 'react';
+import { render } from '@testing-library/react';
+
+import { Masonry, type MasonryHandle } from './index';
+
+const DATA = [100, 200, 300, 400, 500];
+const renderItem = ({ index }: { item: number; index: number }) => <div>{index}</div>;
+
+describe('Masonry — imperative handle', () => {
+  it('exposes scrollToIndex and virtualizer via ref', () => {
+    const ref = createRef<MasonryHandle>();
+    render(<Masonry ref={ref} data={DATA} estimateSize={(i) => DATA[i]} renderItem={renderItem} />);
+
+    expect(typeof ref.current?.scrollToIndex).toBe('function');
+    expect(ref.current?.virtualizer).toBeDefined();
+  });
+
+  it('handle.scrollToIndex forwards to the virtualizer', () => {
+    const ref = createRef<MasonryHandle>();
+    render(<Masonry ref={ref} data={DATA} estimateSize={(i) => DATA[i]} renderItem={renderItem} />);
+
+    const spy = vi.spyOn(ref.current!.virtualizer, 'scrollToIndex');
+    ref.current!.scrollToIndex(3, { align: 'center' });
+
+    expect(spy).toHaveBeenCalledWith(3, { align: 'center' });
+  });
+});

--- a/package/src/Masonry/index.tsx
+++ b/package/src/Masonry/index.tsx
@@ -1,8 +1,26 @@
-import { CSSProperties, ReactNode } from 'react';
+import {
+  CSSProperties,
+  forwardRef,
+  ReactElement,
+  ReactNode,
+  Ref,
+  useImperativeHandle,
+} from 'react';
+import type { ScrollToOptions, Virtualizer } from '@tanstack/react-virtual';
 
 import { useMasonry, type UseMasonryOptions } from '../hooks/useMasonry';
 
 export type { SSRConfig } from '../hooks/useMasonry';
+
+/** Imperative handle exposed via `ref` on {@link Masonry} — the subset of
+ *  {@link useMasonry}'s return worth calling from outside the grid. For anything
+ *  more, use the hook directly. */
+export interface MasonryHandle {
+  /** See {@link useMasonry}'s `scrollToIndex`. */
+  scrollToIndex: (index: number, options?: ScrollToOptions) => void;
+  /** Underlying TanStack virtualizer — escape hatch for other imperative APIs. */
+  virtualizer: Virtualizer<Window, Element>;
+}
 
 // `UseMasonryOptions` is a discriminated union — use intersection, not `extends`.
 type Props<Data> = UseMasonryOptions<Data> & {
@@ -15,18 +33,16 @@ type Props<Data> = UseMasonryOptions<Data> & {
   style?: CSSProperties;
 };
 
-/**
- * Default Masonry component — thin wrapper around {@link useMasonry}. For custom
- * JSX structure (different outer element, extra attributes), use the hook directly.
- *
- * Lane count source: the `--lanes` CSS custom property resolved on the grid root.
- * The library never declares `container-type` — wrap externally for `@container`.
- */
-export function Masonry<Data = unknown>(props: Props<Data>) {
+function MasonryInner<Data>(props: Props<Data>, ref: Ref<MasonryHandle>) {
   // Don't destructure the union-tagged fields — destructuring widens `ssr` /
   // `estimateSize` to optional and breaks the discriminated union narrowing.
   const { renderItem, className, style } = props;
-  const { gridProps, getItemProps, items } = useMasonry(props);
+  const { gridProps, getItemProps, items, scrollToIndex, virtualizer } = useMasonry(props);
+
+  // Imperative access for component users — `scrollToIndex` (and the virtualizer
+  // escape hatch) without dropping to the hook. Hook composers read these off the
+  // return value instead.
+  useImperativeHandle(ref, () => ({ scrollToIndex, virtualizer }), [scrollToIndex, virtualizer]);
 
   return (
     <div {...gridProps} className={className} style={{ ...gridProps.style, ...style }}>
@@ -38,3 +54,19 @@ export function Masonry<Data = unknown>(props: Props<Data>) {
     </div>
   );
 }
+
+/**
+ * Default Masonry component — thin wrapper around {@link useMasonry}. For custom
+ * JSX structure (different outer element, extra attributes), use the hook directly.
+ *
+ * Pass a `ref` typed {@link MasonryHandle} for imperative access (`scrollToIndex`,
+ * the virtualizer escape hatch) without composing the hook yourself.
+ *
+ * Lane count source: the `--lanes` CSS custom property resolved on the grid root.
+ * The library never declares `container-type` — wrap externally for `@container`.
+ */
+// `forwardRef` erases the generic; the cast restores `<Data>` inference at the
+// call site (the peer range includes React 18, where `ref` isn't yet a plain prop).
+export const Masonry = forwardRef(MasonryInner) as <Data = unknown>(
+  props: Props<Data> & { ref?: Ref<MasonryHandle> }
+) => ReactElement;

--- a/package/src/hooks/useMasonry.test.tsx
+++ b/package/src/hooks/useMasonry.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 import { useMasonry } from './useMasonry';
@@ -39,5 +39,64 @@ describe('useMasonry gutter workaround', () => {
 
     rerender({ gutter: 40 });
     expect(measureSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ResizeObserver mock — happy-dom may not provide one; fire synchronously so
+// the virtualizer has a resolved rect/lane count by the time we assert.
+// ---------------------------------------------------------------------------
+type ROCallback = (entries: ResizeObserverEntry[]) => void;
+
+class SyncResizeObserver {
+  private callback: ROCallback;
+  constructor(callback: ROCallback) {
+    this.callback = callback;
+  }
+  observe(target: Element) {
+    this.callback([{ target } as ResizeObserverEntry]);
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+describe('useMasonry — scrollToIndex', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', SyncResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not call the virtualizer unless invoked', () => {
+    const { result } = renderHook(() => useMasonry({ data: [1, 2, 3], estimateSize: () => 100 }));
+
+    const spy = vi.spyOn(result.current.virtualizer, 'scrollToIndex');
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('forwards index and options to the underlying virtualizer', () => {
+    const { result } = renderHook(() => useMasonry({ data: [1, 2, 3], estimateSize: () => 100 }));
+
+    const spy = vi.spyOn(result.current.virtualizer, 'scrollToIndex');
+    result.current.scrollToIndex(2, { align: 'center', behavior: 'smooth' });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(2, { align: 'center', behavior: 'smooth' });
+  });
+
+  it('stays referentially stable across re-renders (safe in effect deps)', () => {
+    const { result, rerender } = renderHook(
+      (props: { data: number[] }) => useMasonry({ data: props.data, estimateSize: () => 100 }),
+      { initialProps: { data: [1, 2, 3] } }
+    );
+
+    const first = result.current.scrollToIndex;
+    rerender({ data: [1, 2, 3, 4] });
+    const second = result.current.scrollToIndex;
+
+    expect(second).toBe(first);
   });
 });

--- a/package/src/hooks/useMasonry.ts
+++ b/package/src/hooks/useMasonry.ts
@@ -1,5 +1,10 @@
-import { CSSProperties, RefObject, useEffect, useRef, useState } from 'react';
-import { useWindowVirtualizer, type VirtualItem, type Virtualizer } from '@tanstack/react-virtual';
+import { CSSProperties, RefObject, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useWindowVirtualizer,
+  type ScrollToOptions,
+  type VirtualItem,
+  type Virtualizer,
+} from '@tanstack/react-virtual';
 
 import { useCSSLaneCount } from './useCSSLaneCount';
 import { useOffsetTop } from './useOffsetTop';
@@ -74,10 +79,22 @@ export interface UseMasonryReturn {
   items: VirtualItem[];
   /** Current lane count — `--lanes` post-mount, fallback pre-mount. */
   lanes: number;
-  /** Underlying TanStack virtualizer (escape hatch for `scrollToIndex` etc.).
-   *  Stable identity + mutable internals — deriving render values from it in a
-   *  compiled component caches stale. Prefer `items`/`lanes`, or `'use no memo'`. */
+  /** Underlying TanStack virtualizer (escape hatch for imperative APIs beyond
+   *  `scrollToIndex`). Stable identity + mutable internals — deriving render
+   *  values from it in a compiled component caches stale. Prefer `items`/`lanes`,
+   *  or `'use no memo'`. */
   virtualizer: Virtualizer<Window, Element>;
+  /**
+   * Scrolls so `index` is positioned per `align` (default `'auto'`: nearest edge,
+   * no-op if already visible). Referentially stable — safe in effect deps.
+   *
+   * A thin forward to TanStack Virtual's
+   * {@link https://tanstack.com/virtual/latest/docs/api/virtualizer#scrolltoindex scrollToIndex}
+   * (`options` is its `ScrollToOptions`). Cold-jump accuracy is bounded by
+   * `estimateSize` — inherent to estimate-based virtualization, not specific to
+   * this library; see the docs for the error model.
+   */
+  scrollToIndex: (index: number, options?: ScrollToOptions) => void;
 }
 
 /**
@@ -147,6 +164,13 @@ export function useMasonry<Data>({
   // against actual container width at paint time.
   const laneWidthCalc = `calc(${100 / lanes}% - ${(gutter * (lanes - 1)) / lanes}px)`;
 
+  // `virtualizer` is a stable class instance (TanStack re-`setOptions`s it in
+  // place), so closing over it keeps this wrapper's identity stable too.
+  const scrollToIndex = useCallback(
+    (index: number, options?: ScrollToOptions) => virtualizer.scrollToIndex(index, options),
+    [virtualizer]
+  );
+
   return {
     gridProps: {
       ref: gridRef,
@@ -173,5 +197,6 @@ export function useMasonry<Data>({
     items,
     lanes,
     virtualizer,
+    scrollToIndex,
   };
 }


### PR DESCRIPTION
## Summary

- Promotes `virtualizer.scrollToIndex` (previously only reachable via the undocumented `virtualizer` escape hatch) to a stable, documented `scrollToIndex(index, options?)` returned directly from `useMasonry`.
- A bare `useCallback` forward to TanStack Virtual's own method, reusing its exported `ScrollToOptions`, referentially stable (safe in effect deps).
- Also reachable from the `<Masonry>` component: pass a `ref` typed `MasonryHandle` (exposes `scrollToIndex` + the `virtualizer` escape hatch) — imperative control without composing the hook. Uses `forwardRef` with a generic-preserving cast (the peer range includes React 18).

## Why no correction loop

Cold-jump landing accuracy is bounded by `estimateSize`, not by our code — this is inherent to any dynamically-measured virtualizer, not a masonry bug. Measured at index 7500 / 10k items, `align: 'start'`:
- unbiased estimate: ~167px drift (4 lanes)
- biased +50px/row: ~93.7k px drift (4 lanes) — grows as `Δ × index / lanes`

Calling `scrollToIndex` twice yields 0px improvement, so a retry/correction loop cannot help. 

The honest accuracy caveat is documented in the JSDoc + docs page. The fix for drift is a closer `estimateSize`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `scrollToIndex(index, options?)` support for masonry layouts.
  * Exposed an imperative ref handle for the masonry component, including access to `scrollToIndex` and the underlying virtualizer.
  * Updated docs with examples showing how to call the new API from a ref.

* **Bug Fixes**
  * Improved API stability so `scrollToIndex` remains consistent across re-renders.
  * Added test coverage to verify scrolling behavior and argument forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->