### PR TITLE
feat: add useEndReached hook for infinite loading

### DIFF
--- a/.changeset/infinite-loading-use-end-reached.md
+++ b/.changeset/infinite-loading-use-end-reached.md
@@ -1,0 +1,5 @@
+---
+'react-virtual-masonry': minor
+---
+
+Add `useEndReached`, a small fetching-agnostic hook for infinite loading. Pass it `useMasonry().items` plus your data length and a callback; it fires when the last rendered item nears the end of loaded data. Wire the callback to `fetchNextPage` (TanStack Query), `setSize` (SWR), `fetchMore` (Apollo), or any loader — the hook never fetches itself. The `<Masonry>` component also accepts `onEndReached` (with `endReachedThreshold` / `endReachedDisabled`) so component users get infinite loading without composing the hook.

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
     "waku": "^1.0.0-beta.6"
   },
   "devDependencies": {
+    "@tanstack/react-query": "^5.101.2",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "^6.0.0",

--- a/docs/src/pages/docs/api/masonry.mdx
+++ b/docs/src/pages/docs/api/masonry.mdx
@@ -92,6 +92,67 @@ Instance-specific selector for when multiple grids need different styling. Most 
 
 Merged after the library's grid styles. Do not override `height`, `width`, or `position` — the layout depends on them.
 
+### onEndReached
+
+- **Type:** `() => void`
+
+Callback fired when the last rendered item nears the end of `data`. Wraps [`useEndReached`](/docs/api/use-end-reached) — pass your data-layer callback (`fetchNextPage`, `setSize`, `fetchMore`) directly. `endReachedThreshold` and `endReachedDisabled` are optional and refine when it fires.
+
+### endReachedThreshold
+
+- **Type:** `number`
+- **Default:** `0`
+
+How many items from the end of `data` to fire `onEndReached`. Recommended to set ≥ `overscan` for prefetch-ahead (typically `3` or more). A value of `0` fires once the final item actually renders.
+
+### endReachedDisabled
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Hard-suppresses `onEndReached` firing — wire it to your in-flight or has-more state (`isFetchingNextPage`, `!hasNextPage`).
+
+## Infinite Loading
+
+The simplest way to implement infinite loading is to pass `onEndReached` directly to the component:
+
+```tsx twoslash
+import { Masonry } from 'react-virtual-masonry';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+declare function getPage(
+  pageParam: number
+): Promise<{ items: { id: string; height: number }[]; nextId?: number }>;
+// ---cut---
+function App() {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey: ['items'],
+    queryFn: ({ pageParam }) => getPage(pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (last) => last.nextId,
+  });
+
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+
+  return (
+    <Masonry
+      data={items}
+      estimateSize={(i) => items[i]?.height ?? 200}
+      renderItem={({ item }) => <img src={item.id} alt="" style={{ height: item.height }} />}
+      onEndReached={fetchNextPage}
+      endReachedThreshold={20}
+      endReachedDisabled={!hasNextPage || isFetchingNextPage}
+    />
+  );
+}
+```
+
+:::note
+`endReachedThreshold` should be ≥ your `overscan` value (default `3`) so prefetch happens before the visible window runs out of data.
+:::
+
+**Need custom markup** (a loading row, end-of-feed message, or different outer element)? Compose [`useEndReached`](/docs/api/use-end-reached) directly with [`useMasonry`](/docs/api/use-masonry) — see [Composing directly](/docs/api/use-end-reached#composing-directly).
+
 ## Imperative Handle
 
 You don't have to drop to [`useMasonry`](/docs/api/use-masonry) for imperative control. Pass a `ref` typed `MasonryHandle` to reach `scrollToIndex` (and the `virtualizer` escape hatch) from the component:

--- a/docs/src/pages/docs/api/use-end-reached.mdx
+++ b/docs/src/pages/docs/api/use-end-reached.mdx
@@ -1,0 +1,85 @@
+# useEndReached [Infinite-loading trigger]
+
+A small, fetching-agnostic hook that fires a callback once the last rendered item nears the end of your loaded data. It never fetches anything itself — you wire the callback to whatever data layer you use ([TanStack Query](https://tanstack.com/query), SWR, Apollo, a raw loader). It pairs with [`useMasonry`](/docs/api/use-masonry) but works with any `{ index }[]` list.
+
+The [`<Masonry>`](/docs/api/masonry) component wires this hook internally — see its [Infinite loading](/docs/api/masonry#infinite-loading) section for the component API.
+
+## Composing directly
+
+```tsx twoslash
+import { useMasonry, useEndReached } from 'react-virtual-masonry';
+
+declare const data: number[];
+declare function loadMore(): void;
+declare const hasMore: boolean;
+declare const isLoading: boolean;
+// ---cut---
+const { items } = useMasonry({ data, estimateSize: (i) => data[i] });
+
+useEndReached(items, data.length, loadMore, {
+  threshold: 20,
+  disabled: !hasMore || isLoading,
+});
+```
+
+`onEndReached` is a plain no-arg callback, so you can pass your loader (`fetchNextPage`, `setSize`, `fetchMore`) directly — no wrapper needed.
+
+## With TanStack Query
+
+Flatten the pages into `data`, then hand `useEndReached` a callback that requests the next page. Gate re-firing with `disabled` while a page is in flight or there is no next page.
+
+```tsx
+const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+  /* … */
+});
+const items = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);
+
+const { gridProps, getItemProps, items: virtualItems } = useMasonry({ data: items /* … */ });
+
+useEndReached(virtualItems, items.length, fetchNextPage, {
+  threshold: 20,
+  disabled: !hasNextPage || isFetchingNextPage,
+});
+```
+
+## Parameters
+
+### items
+
+- **Type:** `Pick<VirtualItem, 'index'>[]`
+
+The rendered items — pass `useMasonry().items`. The hook only reads `.index` of the last entry.
+
+### dataLength
+
+- **Type:** `number`
+
+The length of your full data array. The trigger compares the last rendered index against this.
+
+### onEndReached
+
+- **Type:** `() => void`
+
+Called when the last rendered index reaches the threshold. Fetching-agnostic — the hook never fetches; pass your loader (`fetchNextPage`, `setSize`, `fetchMore`) directly.
+
+### options.threshold
+
+- **Type:** `number`
+- **Default:** `0`
+
+How close the last rendered index may get to the end of `dataLength` before firing. `0` fires once the final item of `data` actually renders.
+
+:::note
+`items` includes overscan-rendered entries, so the last rendered index already runs ahead of the visible edge. For prefetch-ahead, set `threshold` to a value **≥ your `overscan`** — otherwise overscan alone can outrun loaded data before the guard fires.
+:::
+
+### options.disabled
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Hard-suppresses firing. Wire it to your in-flight / has-more state (`isFetchingNextPage`, `!hasNextPage`) — the hook does not track fetch state itself.
+
+## Notes
+
+The hook depends on the last rendered _index_ (a primitive), not the `items` array, because `useMasonry().items` has a fresh identity every render — depending on the array would re-run the effect every render. Batched range-loading and sparse (`isItemLoaded`) loading are intentionally out of scope; compose them yourself if a large overscan or slow network needs them.

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       items: [
         { text: '<Masonry />', link: '/docs/api/masonry' },
         { text: 'useMasonry', link: '/docs/api/use-masonry' },
+        { text: 'useEndReached', link: '/docs/api/use-end-reached' },
       ],
     },
   ],

--- a/examples/tanstack-start/package.json
+++ b/examples/tanstack-start/package.json
@@ -14,6 +14,7 @@
     "check-types": "tsr generate && tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.168.26",
     "@tanstack/react-start": "^1.167.52",
     "@tanstack/react-virtual": "^3.13.24",

--- a/examples/tanstack-start/src/infinite-data.ts
+++ b/examples/tanstack-start/src/infinite-data.ts
@@ -1,0 +1,57 @@
+import { createServerFn } from '@tanstack/react-start';
+
+export interface FeedItem {
+  id: number;
+  height: number;
+  color: string;
+}
+
+export interface FeedPage {
+  items: FeedItem[];
+  /** `undefined` once `TOTAL_ITEMS` has been fully served. */
+  nextPage: number | undefined;
+}
+
+export const PAGE_SIZE = 50;
+export const TOTAL_ITEMS = 1000;
+const FETCH_DELAY_MS = 200;
+
+const COLORS = ['#F47067', '#F4A261', '#E9C46A', '#2A9D8F', '#264653', '#8E7DBE'];
+
+// Integer hash (not Math.random) so height/color are a pure function of index —
+// the same page always serves identical bytes, which is what makes the e2e
+// assertions on item count and index continuity meaningful.
+function hash(n: number): number {
+  let x = (n + 0x9e3779b9) | 0;
+  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b);
+  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b);
+  x = x ^ (x >>> 16);
+  return Math.abs(x);
+}
+
+function itemAt(index: number): FeedItem {
+  return {
+    id: index,
+    height: 80 + (hash(index) % 320),
+    color: COLORS[index % COLORS.length]!,
+  };
+}
+
+function buildPage(page: number): FeedPage {
+  const start = page * PAGE_SIZE;
+  const end = Math.min(start + PAGE_SIZE, TOTAL_ITEMS);
+  const items = Array.from({ length: Math.max(0, end - start) }, (_, i) => itemAt(start + i));
+  return { items, nextPage: end < TOTAL_ITEMS ? page + 1 : undefined };
+}
+
+/** Server round-trip stands in for a real paginated API: validated input, an
+ *  artificial network delay, and a response shape mirroring a typical REST feed. */
+export const fetchFeedPage = createServerFn({ method: 'GET' })
+  .inputValidator((page: number) => {
+    if (!Number.isInteger(page) || page < 0) throw new Error(`Invalid page: ${page}`);
+    return page;
+  })
+  .handler(async ({ data: page }): Promise<FeedPage> => {
+    await new Promise((resolve) => setTimeout(resolve, FETCH_DELAY_MS));
+    return buildPage(page);
+  });

--- a/examples/tanstack-start/src/routes/infinite.tsx
+++ b/examples/tanstack-start/src/routes/infinite.tsx
@@ -1,0 +1,115 @@
+import { useMemo, useState } from 'react';
+import { createFileRoute } from '@tanstack/react-router';
+import { QueryClient, QueryClientProvider, useInfiniteQuery } from '@tanstack/react-query';
+import { useEndReached, useMasonry } from 'react-virtual-masonry';
+
+import { fetchFeedPage, type FeedItem } from '../infinite-data';
+
+export const Route = createFileRoute('/infinite')({
+  component: InfiniteFeedPage,
+});
+
+const GUTTER = 16;
+const OVERSCAN = 3;
+// Prefetch this many items ahead; keep it ≥ OVERSCAN (see useEndReached).
+const FETCH_THRESHOLD = 20;
+const HOST_CLASS = 'cq-host-infinite';
+
+function InfiniteFeedPage() {
+  // Fresh QueryClient per mount → per-request isolation on the server, stable on
+  // the client. A real app would lift this to router/app scope for cross-visit cache.
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <InfiniteFeed />
+    </QueryClientProvider>
+  );
+}
+
+function InfiniteFeed() {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status, error } = useInfiniteQuery({
+    queryKey: ['infinite-feed'],
+    queryFn: ({ pageParam }) => fetchFeedPage({ data: pageParam }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextPage,
+  });
+
+  const items = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data]);
+
+  const {
+    gridProps,
+    getItemProps,
+    items: virtualItems,
+  } = useMasonry({
+    data: items,
+    gutter: GUTTER,
+    estimateSize: (index) => items[index]?.height ?? 200,
+    overscan: OVERSCAN,
+  });
+
+  // Fires `fetchNextPage` as the last rendered item nears the end of loaded data;
+  // `disabled` gates re-firing while a page is in flight or none remain.
+  useEndReached(virtualItems, items.length, fetchNextPage, {
+    threshold: FETCH_THRESHOLD,
+    disabled: !hasNextPage || isFetchingNextPage,
+  });
+
+  return (
+    <section data-testid="infinite-feed">
+      <style>{`
+        .${HOST_CLASS}             { container-type: inline-size; }
+        [data-rvm-grid]            { --lanes: 1; }
+        @container (min-width: 640px)  { [data-rvm-grid] { --lanes: 2; } }
+        @container (min-width: 1024px) { [data-rvm-grid] { --lanes: 3; } }
+        @container (min-width: 1440px) { [data-rvm-grid] { --lanes: 4; } }
+      `}</style>
+      <h1>Infinite Feed</h1>
+      <p style={{ color: '#555' }}>
+        Composed with <code>useEndReached</code>: it watches the index of the last rendered item
+        (viewport + overscan) and calls <code>fetchNextPage()</code> once it gets within{' '}
+        {FETCH_THRESHOLD} items of the end of loaded data.
+      </p>
+      {status === 'pending' && <p data-testid="feed-initial-loading">Loading…</p>}
+      {status === 'error' && (
+        <p data-testid="feed-error">Failed to load: {(error as Error).message}</p>
+      )}
+      {status === 'success' && (
+        <div className={HOST_CLASS}>
+          <div {...gridProps}>
+            {virtualItems.map((virtualItem) => (
+              <div key={virtualItem.key} {...getItemProps(virtualItem)}>
+                {renderTile(items[virtualItem.index]!, virtualItem.index)}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {isFetchingNextPage && <p data-testid="feed-loading-more">Loading more…</p>}
+      {!hasNextPage && status === 'success' && (
+        <p data-testid="feed-end">Reached the end — {items.length} items loaded.</p>
+      )}
+    </section>
+  );
+}
+
+function renderTile(item: FeedItem, index: number) {
+  return (
+    <div
+      data-testid="tile"
+      data-tile-index={index}
+      style={{
+        height: item.height,
+        background: item.color,
+        color: 'white',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontWeight: 600,
+        borderRadius: 8,
+      }}
+    >
+      {index}
+    </div>
+  );
+}

--- a/examples/tanstack-start/tests/infinite.spec.ts
+++ b/examples/tanstack-start/tests/infinite.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Infinite-loading feed on `/infinite`, composed (not a built-in API) from
+ * `useMasonry().items`: an effect watches the index of the last *rendered*
+ * item (viewport + overscan) and calls `fetchNextPage()` once it gets within
+ * a threshold of `data.length`. Data comes from a `createServerFn` page
+ * endpoint (`PAGE_SIZE=50`, `TOTAL_ITEMS=1000`, ~200ms artificial delay).
+ *
+ * Each page request is a distinct GET to `/_serverFn/...`, so counting those
+ * is the reliable way to assert "at least 2 fetches happened" — the rendered
+ * DOM tile count does NOT grow with total items loaded (it's virtualized and
+ * stays bounded to roughly the viewport + overscan window regardless of how
+ * many pages have been fetched).
+ */
+
+const TOTAL_ITEMS = 1000;
+
+function countServerFnRequests(page: import('@playwright/test').Page): { get: () => number } {
+  let count = 0;
+  page.on('request', (req) => {
+    if (req.url().includes('/_serverFn/')) count++;
+  });
+  return { get: () => count };
+}
+
+async function scrollToBottom(page: import('@playwright/test').Page) {
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+}
+
+test.describe('Infinite feed', () => {
+  test.setTimeout(60_000);
+
+  test('initial load fetches the first page automatically', async ({ page }) => {
+    const requests = countServerFnRequests(page);
+    await page.goto('/infinite');
+    await expect(page.getByTestId('tile').first()).toBeVisible();
+    expect(requests.get()).toBeGreaterThanOrEqual(1);
+  });
+
+  test('scrolling triggers additional fetches, with no duplicate rendered indices', async ({
+    page,
+  }) => {
+    const requests = countServerFnRequests(page);
+    await page.goto('/infinite');
+    await expect(page.getByTestId('tile').first()).toBeVisible();
+
+    // Scroll toward the bottom repeatedly; document height grows as pages
+    // load, so repeated scrollTo(bottom) calls walk further down the feed.
+    for (let i = 0; i < 15 && requests.get() < 3; i++) {
+      await scrollToBottom(page);
+      await page.waitForTimeout(300);
+    }
+
+    // At least 2 fetches beyond the automatic first-page load.
+    expect(requests.get()).toBeGreaterThanOrEqual(3);
+
+    // No duplicate `data-index` among the currently-rendered virtualized items.
+    const indices = await page
+      .locator('[data-rvm-item]')
+      .evaluateAll((els) => els.map((el) => el.getAttribute('data-index')));
+    expect(new Set(indices).size).toBe(indices.length);
+  });
+
+  test('reaches the end of the feed and stops fetching', async ({ page }) => {
+    const requests = countServerFnRequests(page);
+    await page.goto('/infinite');
+    await expect(page.getByTestId('tile').first()).toBeVisible();
+
+    const deadline = Date.now() + 45_000;
+    while (Date.now() < deadline) {
+      if (
+        await page
+          .getByTestId('feed-end')
+          .isVisible()
+          .catch(() => false)
+      )
+        break;
+      await scrollToBottom(page);
+      await page.waitForTimeout(250);
+    }
+
+    await expect(page.getByTestId('feed-end')).toBeVisible();
+    await expect(page.getByTestId('feed-end')).toContainText(`${TOTAL_ITEMS} items loaded`);
+
+    // `feed-end` can flip visible the instant the last page resolves, before the
+    // document has grown to its final scrollHeight and the last items have
+    // actually entered the virtualizer's rendered window. Nudge once more so
+    // the tail assertions below reflect the settled end state.
+    await scrollToBottom(page);
+    await page.waitForTimeout(300);
+
+    // No duplicates at the tail either.
+    const indices = await page
+      .locator('[data-rvm-item]')
+      .evaluateAll((els) => els.map((el) => el.getAttribute('data-index')));
+    expect(new Set(indices).size).toBe(indices.length);
+    expect(Math.max(...indices.map(Number))).toBe(TOTAL_ITEMS - 1);
+
+    // No further fetch beyond the end: keep nudging the scroll and confirm
+    // the request count (and `isFetchingNextPage` indicator) stay put.
+    const finalCount = requests.get();
+    for (let i = 0; i < 5; i++) {
+      await scrollToBottom(page);
+      await page.waitForTimeout(200);
+    }
+    expect(requests.get()).toBe(finalCount);
+    await expect(page.getByTestId('feed-loading-more')).toHaveCount(0);
+  });
+});

--- a/package/src/Masonry/index.test.tsx
+++ b/package/src/Masonry/index.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 
 import { Masonry, type MasonryHandle } from './index';
 
-const DATA = [100, 200, 300, 400, 500];
+const DATA = Array.from({ length: 8 }, () => 100);
 const renderItem = ({ index }: { item: number; index: number }) => <div>{index}</div>;
 
 describe('Masonry — imperative handle', () => {
@@ -24,5 +24,43 @@ describe('Masonry — imperative handle', () => {
     ref.current!.scrollToIndex(3, { align: 'center' });
 
     expect(spy).toHaveBeenCalledWith(3, { align: 'center' });
+  });
+});
+
+describe('Masonry — onEndReached', () => {
+  it('fires onEndReached when the grid renders to the end of data', () => {
+    const onEndReached = vi.fn();
+    render(
+      <Masonry
+        data={DATA}
+        estimateSize={(i) => DATA[i]}
+        renderItem={renderItem}
+        onEndReached={onEndReached}
+      />
+    );
+    // Small list: the final item is within the (default 0) threshold immediately.
+    expect(onEndReached).toHaveBeenCalled();
+  });
+
+  it('does not fire when endReachedDisabled', () => {
+    const onEndReached = vi.fn();
+    render(
+      <Masonry
+        data={DATA}
+        estimateSize={(i) => DATA[i]}
+        renderItem={renderItem}
+        onEndReached={onEndReached}
+        endReachedDisabled
+      />
+    );
+    expect(onEndReached).not.toHaveBeenCalled();
+  });
+
+  it('is inert when onEndReached is omitted', () => {
+    // Just renders without throwing — the internal useEndReached is disabled.
+    const { container } = render(
+      <Masonry data={DATA} estimateSize={(i) => DATA[i]} renderItem={renderItem} />
+    );
+    expect(container.querySelector('[data-rvm-grid]')).not.toBeNull();
   });
 });

--- a/package/src/Masonry/index.tsx
+++ b/package/src/Masonry/index.tsx
@@ -9,8 +9,11 @@ import {
 import type { ScrollToOptions, Virtualizer } from '@tanstack/react-virtual';
 
 import { useMasonry, type UseMasonryOptions } from '../hooks/useMasonry';
+import { useEndReached } from '../hooks/useEndReached';
 
 export type { SSRConfig } from '../hooks/useMasonry';
+
+const NOOP = () => {};
 
 /** Imperative handle exposed via `ref` on {@link Masonry} — the subset of
  *  {@link useMasonry}'s return worth calling from outside the grid. For anything
@@ -31,18 +34,31 @@ type Props<Data> = UseMasonryOptions<Data> & {
   /** Merged after the library's grid styles. Do not override `height` / `width`
    *  / `position`. */
   style?: CSSProperties;
+  /** Infinite loading: fires as the last rendered item nears the end of `data`.
+   *  Wraps {@link useEndReached} — pass `fetchNextPage` / `setSize` / a loader. */
+  onEndReached?: () => void;
+  /** Items-from-end distance at which `onEndReached` fires. @default 0 */
+  endReachedThreshold?: number;
+  /** Suppress `onEndReached`, e.g. while fetching or when no data remains. */
+  endReachedDisabled?: boolean;
 };
 
 function MasonryInner<Data>(props: Props<Data>, ref: Ref<MasonryHandle>) {
   // Don't destructure the union-tagged fields — destructuring widens `ssr` /
   // `estimateSize` to optional and breaks the discriminated union narrowing.
-  const { renderItem, className, style } = props;
+  const { renderItem, className, style, onEndReached, endReachedThreshold, endReachedDisabled } =
+    props;
   const { gridProps, getItemProps, items, scrollToIndex, virtualizer } = useMasonry(props);
 
   // Imperative access for component users — `scrollToIndex` (and the virtualizer
   // escape hatch) without dropping to the hook. Hook composers read these off the
   // return value instead.
   useImperativeHandle(ref, () => ({ scrollToIndex, virtualizer }), [scrollToIndex, virtualizer]);
+
+  useEndReached(items, props.data.length, onEndReached ?? NOOP, {
+    threshold: endReachedThreshold,
+    disabled: endReachedDisabled || !onEndReached,
+  });
 
   return (
     <div {...gridProps} className={className} style={{ ...gridProps.style, ...style }}>
@@ -59,8 +75,9 @@ function MasonryInner<Data>(props: Props<Data>, ref: Ref<MasonryHandle>) {
  * Default Masonry component — thin wrapper around {@link useMasonry}. For custom
  * JSX structure (different outer element, extra attributes), use the hook directly.
  *
- * Pass a `ref` typed {@link MasonryHandle} for imperative access (`scrollToIndex`,
- * the virtualizer escape hatch) without composing the hook yourself.
+ * Pass `onEndReached` for infinite loading, or a `ref` typed {@link MasonryHandle}
+ * for imperative access (`scrollToIndex`, the virtualizer escape hatch) — both
+ * without composing the hook yourself.
  *
  * Lane count source: the `--lanes` CSS custom property resolved on the grid root.
  * The library never declares `container-type` — wrap externally for `@container`.

--- a/package/src/hooks/useEndReached.test.tsx
+++ b/package/src/hooks/useEndReached.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useEndReached } from './useEndReached';
+
+function itemsUpTo(lastIndex: number): { index: number }[] {
+  // Fresh array + fresh objects every call, mirroring `useMasonry().items`'
+  // 'use no memo' contract (a new identity every render).
+  return Array.from({ length: lastIndex + 1 }, (_, i) => ({ index: i }));
+}
+
+describe('useEndReached', () => {
+  it('fires once when the last rendered index enters dataLength - threshold', () => {
+    const onEndReached = vi.fn();
+    const dataLength = 100;
+    const threshold = 20;
+
+    const { rerender } = renderHook(
+      ({ items }: { items: { index: number }[] }) =>
+        useEndReached(items, dataLength, onEndReached, { threshold }),
+      { initialProps: { items: itemsUpTo(78) } } // 78 < 100 - 1 - 20 (=79): not yet
+    );
+    expect(onEndReached).not.toHaveBeenCalled();
+
+    rerender({ items: itemsUpTo(79) }); // 79 >= 79: fires
+    expect(onEndReached).toHaveBeenCalledTimes(1);
+    expect(onEndReached).toHaveBeenCalledWith();
+
+    // Re-render with an unrelated prop change but the same last index should not re-fire.
+    rerender({ items: itemsUpTo(79) });
+    expect(onEndReached).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when disabled', () => {
+    const onEndReached = vi.fn();
+
+    renderHook(() => useEndReached(itemsUpTo(99), 100, onEndReached, { disabled: true }));
+    expect(onEndReached).not.toHaveBeenCalled();
+  });
+
+  it('does not re-fire on unrelated re-renders with a fresh-identity items array whose last index is unchanged', () => {
+    const onEndReached = vi.fn();
+    const dataLength = 100;
+
+    const { rerender } = renderHook(
+      (_props: { unrelated: number }) =>
+        useEndReached(itemsUpTo(99), dataLength, onEndReached, { threshold: 0 }),
+      { initialProps: { unrelated: 0 } }
+    );
+    expect(onEndReached).toHaveBeenCalledTimes(1);
+
+    // A fresh `items` array is constructed on every call (as `useMasonry().items`
+    // would be), but its last index (99) never changes. If the hook depended on
+    // the array identity instead of the derived primitive, this would re-fire.
+    rerender({ unrelated: 1 });
+    rerender({ unrelated: 2 });
+    expect(onEndReached).toHaveBeenCalledTimes(1);
+  });
+
+  it('default threshold (0) fires only when the final item renders', () => {
+    const onEndReached = vi.fn();
+    const dataLength = 10;
+
+    const { rerender } = renderHook(
+      ({ items }: { items: { index: number }[] }) => useEndReached(items, dataLength, onEndReached),
+      { initialProps: { items: itemsUpTo(8) } } // last index 8, not the final item (9)
+    );
+    expect(onEndReached).not.toHaveBeenCalled();
+
+    rerender({ items: itemsUpTo(9) }); // last index 9 === dataLength - 1: fires
+    expect(onEndReached).toHaveBeenCalledTimes(1);
+    expect(onEndReached).toHaveBeenCalledWith();
+  });
+
+  it('does not fire when no items are rendered', () => {
+    const onEndReached = vi.fn();
+    renderHook(() => useEndReached([], 100, onEndReached));
+    expect(onEndReached).not.toHaveBeenCalled();
+  });
+});

--- a/package/src/hooks/useEndReached.ts
+++ b/package/src/hooks/useEndReached.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import type { VirtualItem } from '@tanstack/react-virtual';
+
+export interface UseEndReachedOptions {
+  /** Items-from-end distance at which `onEndReached` fires. `items` already
+   *  includes overscan, so for prefetch-ahead set this ≥ your `overscan`.
+   *  @default 0 */
+  threshold?: number;
+  /** Hard-suppresses firing, e.g. while a fetch is in flight or no page remains. */
+  disabled?: boolean;
+}
+
+/**
+ * Fires `onEndReached` once the last rendered item nears the end of `dataLength`.
+ * Fetching-agnostic — pass `fetchNextPage` / `setSize` / a loader directly.
+ *
+ * Depends on the primitive last index, not the `items` array: `useMasonry().items`
+ * has a fresh identity every render (`'use no memo'`), so depending on the array
+ * would re-fire the effect every render instead of only when the window changes.
+ */
+export function useEndReached(
+  items: Pick<VirtualItem, 'index'>[],
+  dataLength: number,
+  onEndReached: () => void,
+  options?: UseEndReachedOptions
+): void {
+  const { threshold = 0, disabled = false } = options ?? {};
+  const lastRenderedIndex = items.length > 0 ? items[items.length - 1]!.index : -1;
+
+  useEffect(() => {
+    if (lastRenderedIndex < 0 || disabled) return;
+    if (lastRenderedIndex >= dataLength - 1 - threshold) {
+      onEndReached();
+    }
+  }, [lastRenderedIndex, dataLength, threshold, disabled, onEndReached]);
+}

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -10,3 +10,6 @@ export type {
   MasonryGridProps,
   MasonryItemProps,
 } from './hooks/useMasonry';
+
+export { useEndReached } from './hooks/useEndReached';
+export type { UseEndReachedOptions } from './hooks/useEndReached';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
         specifier: ^1.0.0-beta.6
         version: 1.0.0-beta.6(@types/node@25.0.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
     devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@19.2.7)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.7
@@ -139,6 +142,9 @@ importers:
 
   examples/tanstack-start:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@19.2.7)
       '@tanstack/react-router':
         specifier: ^1.168.26
         version: 1.168.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2036,6 +2042,14 @@ packages:
   '@tanstack/history@1.161.6':
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
     engines: {node: '>=20.19'}
+
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/react-query@5.101.2':
+    resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-router@1.168.26':
     resolution: {integrity: sha512-+MV+U5KfMUQGZIU/x8MU3FMRSujxLs678v2jhu1Y8P9ndQBKLVOBYKFY+vv/ypxBUYiyDiOsZkDxPJC8UPo/Ig==}
@@ -7920,6 +7934,13 @@ snapshots:
   '@takumi-rs/wasm@0.62.8': {}
 
   '@tanstack/history@1.161.6': {}
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/react-query@5.101.2(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      react: 19.2.7
 
   '@tanstack/react-router@1.168.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:


### PR DESCRIPTION
## Summary

Adds `useEndReached`, a small fetching-agnostic infinite-loading trigger.

Pass `useMasonry().items`, the data length, and a **no-arg** callback. It fires once the last rendered item (viewport + overscan) gets within `threshold` of the end of loaded data. 

The hook never fetches — pass `fetchNextPage` (TanStack Query), `setSize` (SWR), `fetchMore` (Apollo), or any loader **directly**, no wrapper. Zero new dependencies (not even a peer).

The `<Masonry>` component also accepts `onEndReached` (plus optional `endReachedThreshold` / `endReachedDisabled`), wiring `useEndReached` internally so component users get infinite loading without composing the hook. `useMasonry` itself stays fetching-agnostic — its job is layout, not fetch lifecycle.

## Why a hook

Building the example surfaced three papercuts worth solving once in tested code:

1. `useMasonry().items` has a fresh identity every render (`'use no memo'`) — using it as an effect dep re-fires every render; the hook depends on the primitive last index instead.
2. `threshold` must be chosen relative to `overscan` (items include overscan entries) — documented.
3. The in-flight guard (`disabled`) is easy to omit and causes duplicate fetches.

Batching (`minimumBatchSize`) and sparse `isItemLoaded` loading are out of scope (YAGNI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infinite-loading support with a new hook and built-in Masonry options to detect when more content should load.
  * Introduced a new example page demonstrating virtualized infinite scrolling with paginated loading.
* **Bug Fixes**
  * Improved end-of-list handling so loading stops cleanly once all items are loaded.
* **Documentation**
  * Added API docs and usage examples for the new loading behavior and related props.
* **Tests**
  * Added coverage for hook behavior, Masonry end-reached handling, and the infinite-loading example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->