### PR TITLE
feat: virtualize inside a scroll container via scrollElementRef

### DIFF
--- a/.changeset/custom-scroll-container.md
+++ b/.changeset/custom-scroll-container.md
@@ -1,0 +1,5 @@
+---
+'react-virtual-masonry': minor
+---
+
+Add `scrollElementRef` to `useMasonry` for virtualizing inside a scroll container. Pass a ref to an `overflow:auto` element and the grid windows against that element instead of the page; omit it for window scrolling (unchanged default). Container mode is client-only — `scrollElementRef` and `ssr` are mutually exclusive at the type level. Content above the grid inside the container must have stable height (simplest: make the grid the container's first child).

--- a/docs/src/pages/docs/api/masonry.mdx
+++ b/docs/src/pages/docs/api/masonry.mdx
@@ -59,6 +59,13 @@ Gap between items in pixels, applied both between lanes and between items within
 
 Number of items rendered beyond the visible window, passed through to the underlying virtualizer.
 
+### scrollElementRef
+
+- **Type:** `RefObject<HTMLElement | null>`
+- **Default:** `undefined` (window scrolling)
+
+Virtualize inside an `overflow:auto` element instead of the page. Own the scroll container yourself, pass its ref, and drop `<Masonry>` inside it — the grid then windows against that element's scroll position. See [Scrolling in a Container](/docs/scrolling-in-a-container) for the full example and constraints. Mutually exclusive with `ssr` (container mode is client-only).
+
 ### ssr
 
 - **Type:** `SSRConfig`

--- a/docs/src/pages/docs/api/use-masonry.mdx
+++ b/docs/src/pages/docs/api/use-masonry.mdx
@@ -64,7 +64,29 @@ Number of items rendered beyond the visible window.
 - **Type:** `SSRConfig`
 - **Default:** `undefined` (client-only rendering)
 
-SSR rendering configuration — see [`<Masonry /> › ssr`](/docs/api/masonry#ssr).
+SSR rendering configuration — see [`<Masonry /> › ssr`](/docs/api/masonry#ssr). Mutually exclusive with `scrollElementRef` (SSR is window-only).
+
+### scrollElementRef
+
+- **Type:** `RefObject<HTMLElement | null>`
+- **Default:** `undefined` (window scrolling)
+
+Virtualize inside an `overflow:auto` element instead of the page. Pass a ref to the scroll container and the grid windows against that element's scroll position; omit it for the default window scrolling.
+
+```tsx
+const scrollRef = useRef<HTMLDivElement>(null);
+const { gridProps, getItemProps, items } = useMasonry({ data, scrollElementRef: scrollRef });
+
+return (
+  <div ref={scrollRef} style={{ height: 600, overflow: 'auto' }}>
+    <div {...gridProps}>{/* items */}</div>
+  </div>
+);
+```
+
+:::warning
+Container mode is client-only — `scrollElementRef` and `ssr` cannot be combined (it's a compile error). Content **above** the grid inside the container must have stable height: a fixed-height scroll container has no resize signal for content growing above the grid. The simplest layout makes the grid the container's first (or only) child.
+:::
 
 ## Returns
 
@@ -96,9 +118,9 @@ Current lane count — resolved from the `--lanes` CSS custom property post-moun
 
 ### virtualizer
 
-- **Type:** `Virtualizer<Window, Element>`
+- **Type:** `Virtualizer<HTMLElement, Element> | Virtualizer<Window, Element>`
 
-The underlying TanStack virtualizer — an escape hatch for imperative APIs beyond `scrollToIndex` (e.g. `scrollToOffset`, `measure`).
+The underlying TanStack virtualizer — an escape hatch for imperative APIs beyond `scrollToIndex` (e.g. `scrollToOffset`, `measure`). Element-scoped when `scrollElementRef` is set, otherwise window-scoped.
 
 :::warning
 The virtualizer has a stable identity with mutable internals. Deriving render values from it inside a React-Compiler-compiled component caches stale results — prefer `items` / `lanes`, or opt out with `'use no memo'`.

--- a/docs/src/pages/docs/scrolling-in-a-container.mdx
+++ b/docs/src/pages/docs/scrolling-in-a-container.mdx
@@ -4,6 +4,34 @@ By default the grid virtualizes against the **window** — it assumes the page i
 
 ## Usage
 
+Own the scroll container, pass its ref, and render [`<Masonry>`](/docs/api/masonry) inside it:
+
+```tsx
+import { useRef } from 'react';
+import { Masonry } from 'react-virtual-masonry';
+
+function Panel({ data }: { data: number[] }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div ref={scrollRef} style={{ height: 600, overflow: 'auto' }}>
+      <Masonry
+        data={data}
+        estimateSize={(i) => data[i]}
+        scrollElementRef={scrollRef}
+        renderItem={({ item, index }) => <div style={{ height: item }}>{index}</div>}
+      />
+    </div>
+  );
+}
+```
+
+Omit `scrollElementRef` and everything falls back to window scrolling — the default behavior is unchanged.
+
+## Composing with the hook
+
+`scrollElementRef` is a plain [`useMasonry`](/docs/api/use-masonry) option, so a fully custom element structure gets the same behavior:
+
 ```tsx
 import { useRef } from 'react';
 import { useMasonry } from 'react-virtual-masonry';
@@ -29,8 +57,6 @@ function Panel({ data }: { data: number[] }) {
   );
 }
 ```
-
-Omit `scrollElementRef` and everything falls back to window scrolling — the default behavior is unchanged.
 
 ## Constraints
 

--- a/docs/src/pages/docs/scrolling-in-a-container.mdx
+++ b/docs/src/pages/docs/scrolling-in-a-container.mdx
@@ -1,0 +1,47 @@
+# Scrolling in a Container [Virtualize inside a scroll element instead of the page]
+
+By default the grid virtualizes against the **window** — it assumes the page itself scrolls. To embed a masonry grid inside a scrollable panel (a modal, a sidebar feed, a dashboard widget), pass a ref to that `overflow:auto` element as `scrollElementRef`. The grid then windows against the element's scroll position instead of `window.scrollY`.
+
+## Usage
+
+```tsx
+import { useRef } from 'react';
+import { useMasonry } from 'react-virtual-masonry';
+
+function Panel({ data }: { data: number[] }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { gridProps, getItemProps, items } = useMasonry({
+    data,
+    estimateSize: (i) => data[i],
+    scrollElementRef: scrollRef,
+  });
+
+  return (
+    <div ref={scrollRef} style={{ height: 600, overflow: 'auto' }}>
+      <div {...gridProps}>
+        {items.map((item) => (
+          <div key={item.key} {...getItemProps(item)}>
+            {/* render data[item.index] */}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+Omit `scrollElementRef` and everything falls back to window scrolling — the default behavior is unchanged.
+
+## Constraints
+
+:::warning
+**Container mode is client-only.** `scrollElementRef` and [`ssr`](/docs/api/use-masonry#ssr) are mutually exclusive — passing both is a compile error. Server-rendered positioned HTML inside a scroll container is a known follow-up.
+:::
+
+:::warning
+**Content above the grid must have stable height.** A fixed-height scroll container has no resize signal when its content _above_ the grid grows or shrinks, so the grid's offset can go stale. The simplest reliable layout makes the grid the container's first (or only) child. If you need content above it, keep that content's height fixed.
+:::
+
+## Responsive columns
+
+Lane count is still CSS-driven via `--lanes`. Because the container has a known width, `@container` queries pair naturally — give the scroll element (or a wrapper) `container-type: inline-size` and drive `--lanes` off its width rather than the viewport's. See [Getting Started › Responsive Lane Count](/docs/getting-started).

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       text: 'Introduction',
       items: [
         { text: 'Getting Started', link: '/docs/getting-started' },
+        { text: 'Scrolling in a Container', link: '/docs/scrolling-in-a-container' },
         { text: 'Demo', link: '/demo' },
       ],
     },

--- a/package/src/Masonry/index.test.tsx
+++ b/package/src/Masonry/index.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRef } from 'react';
 import { render } from '@testing-library/react';
 
@@ -62,5 +62,60 @@ describe('Masonry — onEndReached', () => {
       <Masonry data={DATA} estimateSize={(i) => DATA[i]} renderItem={renderItem} />
     );
     expect(container.querySelector('[data-rvm-grid]')).not.toBeNull();
+  });
+});
+
+// The `scrollElementRef` option flows through `<Masonry>` to `useMasonry` untouched
+// (props aren't destructured), so container mode is reachable with the component alone
+// — no need to compose the hook. useMasonry.container.test.ts proves the scroll-tracking
+// math; this just proves the prop reaches the element-scoped virtualizer via the component.
+describe('Masonry — scrollElementRef (container mode)', () => {
+  let scrollEl: HTMLDivElement;
+
+  beforeEach(() => {
+    class ImmediateResizeObserver {
+      constructor(private cb: (entries: ResizeObserverEntry[]) => void) {}
+      observe(target: Element) {
+        this.cb([{ target } as ResizeObserverEntry]);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', ImmediateResizeObserver);
+
+    scrollEl = document.createElement('div');
+    // happy-dom has no layout engine — stub the surface the virtualizer reads.
+    Object.defineProperty(scrollEl, 'offsetHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollEl, 'offsetWidth', { value: 800, configurable: true });
+    Object.defineProperty(scrollEl, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollEl, 'scrollHeight', { value: 100_000, configurable: true });
+    Object.defineProperty(scrollEl, 'scrollTop', { value: 0, writable: true, configurable: true });
+    document.body.appendChild(scrollEl);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.removeChild(scrollEl);
+  });
+
+  it('scopes the virtualizer to the ref-passed container', () => {
+    const ref = createRef<MasonryHandle>();
+    const data = Array.from({ length: 1000 }, (_, i) => i);
+
+    render(
+      <Masonry
+        ref={ref}
+        data={data}
+        estimateSize={() => 100}
+        scrollElementRef={{ current: scrollEl }}
+        renderItem={renderItem}
+      />
+    );
+
+    // Element-scoped, not window — the prop reached the element virtualizer.
+    // (Scroll-tracking/windowing math is covered in useMasonry.container.test.ts;
+    // item DOM measures to 0 under happy-dom, so a mounted-count bound is unreliable here.)
+    expect(ref.current?.virtualizer.scrollElement).toBe(scrollEl);
+    expect(document.querySelectorAll('[data-rvm-item]').length).toBeGreaterThan(0);
   });
 });

--- a/package/src/Masonry/index.tsx
+++ b/package/src/Masonry/index.tsx
@@ -21,8 +21,9 @@ const NOOP = () => {};
 export interface MasonryHandle {
   /** See {@link useMasonry}'s `scrollToIndex`. */
   scrollToIndex: (index: number, options?: ScrollToOptions) => void;
-  /** Underlying TanStack virtualizer — escape hatch for other imperative APIs. */
-  virtualizer: Virtualizer<Window, Element>;
+  /** Underlying TanStack virtualizer — escape hatch for other imperative APIs.
+   *  Element-scoped when `scrollElementRef` is set, else window-scoped. */
+  virtualizer: Virtualizer<HTMLElement, Element> | Virtualizer<Window, Element>;
 }
 
 // `UseMasonryOptions` is a discriminated union — use intersection, not `extends`.

--- a/package/src/hooks/useContainerOffsetTop.test.ts
+++ b/package/src/hooks/useContainerOffsetTop.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useContainerOffsetTop } from './useContainerOffsetTop';
+
+describe('useContainerOffsetTop', () => {
+  beforeEach(() => {
+    class ImmediateResizeObserver {
+      constructor(private cb: (entries: ResizeObserverEntry[]) => void) {}
+      observe(target: Element) {
+        this.cb([{ target } as ResizeObserverEntry]);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', ImmediateResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns fallback when either ref has no element', () => {
+    const { result } = renderHook(() =>
+      useContainerOffsetTop({ current: null }, { current: null }, { fallback: 7 })
+    );
+    expect(result.current).toBe(7);
+  });
+
+  it('is relative to the container padding-box top (excludes the top border)', () => {
+    const container = document.createElement('div');
+    const el = document.createElement('div');
+    container.appendChild(el);
+    document.body.appendChild(container);
+
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({ top: 100 } as DOMRect);
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({ top: 150 } as DOMRect);
+    // 10px top border: padding-box top is at 110, so the grid sits 40px into the
+    // scroll content — not 50px. Dropping `clientTop` is what keeps items aligned.
+    Object.defineProperty(container, 'clientTop', { value: 10, configurable: true });
+    Object.defineProperty(container, 'scrollTop', { value: 0, writable: true, configurable: true });
+
+    const { result } = renderHook(() =>
+      useContainerOffsetTop({ current: el }, { current: container }, { fallback: 0 })
+    );
+
+    expect(result.current).toBe(40);
+
+    document.body.removeChild(container);
+  });
+});

--- a/package/src/hooks/useContainerOffsetTop.ts
+++ b/package/src/hooks/useContainerOffsetTop.ts
@@ -1,0 +1,53 @@
+import { RefObject, useCallback, useSyncExternalStore } from 'react';
+
+interface UseContainerOffsetTopOptions {
+  /** Value returned during SSR, before mount, and whenever a ref has no element. */
+  fallback: number;
+}
+
+/**
+ * Container-relative analogue of `useOffsetTop`: the distance from `containerRef`'s
+ * content-box top (`scrollTop === 0`) to `elementRef`'s top, as a
+ * `useSyncExternalStore` snapshot — used as `scrollMargin` in container mode.
+ *
+ * `containerRef` is optional so this can run unconditionally alongside `useOffsetTop`
+ * (rules-of-hooks); omit it in window mode and it always returns `fallback`.
+ */
+export const useContainerOffsetTop = (
+  elementRef: RefObject<HTMLElement | null>,
+  containerRef: RefObject<HTMLElement | null> | undefined,
+  { fallback }: UseContainerOffsetTopOptions
+): number => {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const el = elementRef.current;
+      const container = containerRef?.current;
+      if (!el || !container || typeof ResizeObserver === 'undefined') return () => {};
+      const observer = new ResizeObserver(onStoreChange);
+      observer.observe(el);
+      observer.observe(container);
+      return () => observer.disconnect();
+    },
+    [elementRef, containerRef]
+  );
+
+  const getSnapshot = useCallback((): number => {
+    const el = elementRef.current;
+    const container = containerRef?.current;
+    if (!el || !container) return fallback;
+    // rect `top`s move opposite to `scrollTop`, so this stays scroll-invariant.
+    // `clientTop` drops the container's top border, making the result relative to the
+    // padding-box top (where `scrollTop === 0`) that TanStack uses for `scrollMargin` —
+    // same contract as `offsetTop` in the window case.
+    return (
+      el.getBoundingClientRect().top -
+      container.getBoundingClientRect().top -
+      container.clientTop +
+      container.scrollTop
+    );
+  }, [elementRef, containerRef, fallback]);
+
+  const getServerSnapshot = useCallback(() => fallback, [fallback]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+};

--- a/package/src/hooks/useMasonry.container.test.ts
+++ b/package/src/hooks/useMasonry.container.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { useMasonry, type UseMasonryOptions } from './useMasonry';
+
+// Proves items virtualize against a 400px-tall `overflow:auto` element instead
+// of the window when `scrollElementRef` is passed, that the visible range tracks
+// that element's `scrollTop` (not `window.scrollY`), and that omitting the ref
+// leaves window mode untouched.
+describe('useMasonry — scrollElementRef', () => {
+  let container: HTMLDivElement;
+  let scrollTop = 0;
+
+  beforeEach(() => {
+    class ImmediateResizeObserver {
+      constructor(private cb: (entries: ResizeObserverEntry[]) => void) {}
+      observe(target: Element) {
+        this.cb([{ target } as ResizeObserverEntry]);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', ImmediateResizeObserver);
+
+    container = document.createElement('div');
+    // happy-dom has no layout engine — stub the rect/scroll surface the
+    // virtualizer reads (mirrors the offsetTop stubbing in useOffsetTop.test.ts).
+    Object.defineProperty(container, 'offsetHeight', { value: 400, configurable: true });
+    Object.defineProperty(container, 'offsetWidth', { value: 800, configurable: true });
+    Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(container, 'scrollHeight', { value: 100_000, configurable: true });
+    scrollTop = 0;
+    Object.defineProperty(container, 'scrollTop', {
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = v;
+      },
+      configurable: true,
+    });
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.removeChild(container);
+  });
+
+  it('renders a windowed slice of a 1000-item list scoped to the container', () => {
+    const data = Array.from({ length: 1000 }, (_, i) => i);
+    const scrollElementRef = { current: container };
+
+    const { result } = renderHook(() =>
+      useMasonry({ data, estimateSize: () => 100, scrollElementRef })
+    );
+
+    // Virtualized: nowhere near all 1000 items are in the visible range.
+    expect(result.current.items.length).toBeGreaterThan(0);
+    expect(result.current.items.length).toBeLessThan(50);
+
+    // Scoped to the container, not window.scrollY (which stays 0 throughout).
+    const initialMaxIndex = Math.max(...result.current.items.map((item) => item.index));
+
+    act(() => {
+      container.scrollTop = 5000;
+      container.dispatchEvent(new Event('scroll'));
+    });
+
+    const scrolledIndexes = result.current.items.map((item) => item.index);
+    const scrolledMinIndex = Math.min(...scrolledIndexes);
+
+    expect(scrolledMinIndex).toBeGreaterThan(initialMaxIndex);
+  });
+
+  it('leaves window scroll mode unaffected when scrollElementRef is omitted', () => {
+    const data = Array.from({ length: 20 }, (_, i) => i);
+
+    const { result } = renderHook(() => useMasonry({ data, estimateSize: () => 100 }));
+
+    // `virtualizer.scrollElement` resolves to the window global, not the
+    // (unused, disabled) element virtualizer's container.
+    expect(result.current.virtualizer.scrollElement).toBe(window);
+  });
+
+  it('rejects `ssr` + `scrollElementRef` together at the type level', () => {
+    const scrollElementRef = { current: null as HTMLElement | null };
+    // Container mode is client-only; SSR is window-only. Passing both must not
+    // compile — `scrollElementRef` is typed `never` on the SSR arm, so the
+    // object matches neither union member.
+    // @ts-expect-error scrollElementRef is not allowed alongside ssr
+    const invalid: UseMasonryOptions<number> = {
+      data: [1, 2, 3],
+      estimateSize: () => 100,
+      ssr: { itemCount: 3 },
+      scrollElementRef,
+    };
+    expect(invalid).toBeDefined();
+  });
+});

--- a/package/src/hooks/useMasonry.ts
+++ b/package/src/hooks/useMasonry.ts
@@ -1,11 +1,13 @@
 import { CSSProperties, RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import {
+  useVirtualizer,
   useWindowVirtualizer,
   type ScrollToOptions,
   type VirtualItem,
   type Virtualizer,
 } from '@tanstack/react-virtual';
 
+import { useContainerOffsetTop } from './useContainerOffsetTop';
 import { useCSSLaneCount } from './useCSSLaneCount';
 import { useOffsetTop } from './useOffsetTop';
 
@@ -13,9 +15,7 @@ const DEFAULT_LANES = 4;
 const DEFAULT_OVERSCAN = 3;
 const DEFAULT_GUTTER = 20;
 
-/** SSR rendering configuration. Pass to opt into server-rendered positioned items.
- *  Server-side layout cost scales with `data.length`, not `itemCount` — lane
- *  assignment is order-dependent, so the whole list is laid out per request. */
+/** SSR rendering configuration — opt into server-rendered positioned items. */
 export interface SSRConfig {
   /** Number of items to render in server HTML. */
   itemCount: number;
@@ -33,23 +33,24 @@ interface BaseOptions<Data> {
 
 interface ClientOnlyOptions<Data> extends BaseOptions<Data> {
   ssr?: undefined;
-  /** Optional in client-only mode — items get measured post-mount. Recommended for
-   *  large lists so off-screen sizes contribute to `getTotalSize()` and lane balance. */
+  /** Optional in client-only mode (items measure post-mount); recommended for large
+   *  lists so off-screen sizes feed `getTotalSize()` and lane balance. */
   estimateSize?: (index: number) => number;
+  /** Virtualize inside this `overflow:auto` element instead of the window; omit for
+   *  window scrolling. Mutually exclusive with `ssr` (container mode is client-only). */
+  scrollElementRef?: RefObject<HTMLElement | null>;
 }
 
 interface SSROptions<Data> extends BaseOptions<Data> {
   ssr: SSRConfig;
-  /** Required with `ssr` — server has no DOM to measure, so this is the only height
-   *  source for SSR HTML. Without it every item collapses to 0 and the server output
-   *  is broken. */
+  /** Required with `ssr` — the only height source for server HTML (no DOM to measure). */
   estimateSize: (index: number) => number;
+  /** `never` so `scrollElementRef` can't combine with `ssr` (SSR is window-only). */
+  scrollElementRef?: never;
 }
 
-/**
- * Options for {@link useMasonry}. Discriminated on `ssr`: opting into SSR makes
- * `estimateSize` required so server output is well-formed.
- */
+/** Options for {@link useMasonry}. Discriminated on `ssr`: SSR requires `estimateSize`
+ *  and excludes `scrollElementRef` (SSR is window-only). */
 export type UseMasonryOptions<Data> = ClientOnlyOptions<Data> | SSROptions<Data>;
 
 /** Spread onto the grid root element. */
@@ -79,21 +80,14 @@ export interface UseMasonryReturn {
   items: VirtualItem[];
   /** Current lane count — `--lanes` post-mount, fallback pre-mount. */
   lanes: number;
-  /** Underlying TanStack virtualizer (escape hatch for imperative APIs beyond
-   *  `scrollToIndex`). Stable identity + mutable internals — deriving render
-   *  values from it in a compiled component caches stale. Prefer `items`/`lanes`,
-   *  or `'use no memo'`. */
-  virtualizer: Virtualizer<Window, Element>;
-  /**
-   * Scrolls so `index` is positioned per `align` (default `'auto'`: nearest edge,
-   * no-op if already visible). Referentially stable — safe in effect deps.
-   *
-   * A thin forward to TanStack Virtual's
-   * {@link https://tanstack.com/virtual/latest/docs/api/virtualizer#scrolltoindex scrollToIndex}
-   * (`options` is its `ScrollToOptions`). Cold-jump accuracy is bounded by
-   * `estimateSize` — inherent to estimate-based virtualization, not specific to
-   * this library; see the docs for the error model.
-   */
+  /** Underlying TanStack virtualizer — escape hatch for imperative APIs beyond
+   *  `scrollToIndex`. Element-scoped when `scrollElementRef` is set, else window-scoped.
+   *  Stable identity + mutable internals: prefer `items`/`lanes` in render (or `'use no memo'`). */
+  virtualizer: Virtualizer<HTMLElement, Element> | Virtualizer<Window, Element>;
+  /** Scrolls so `index` is positioned per `options.align` (default `'auto'`). Referentially
+   *  stable — safe in effect deps. Thin forward to TanStack Virtual's
+   *  {@link https://tanstack.com/virtual/latest/docs/api/virtualizer#scrolltoindex scrollToIndex};
+   *  cold-jump accuracy is bounded by `estimateSize` (see docs). */
   scrollToIndex: (index: number, options?: ScrollToOptions) => void;
 }
 
@@ -101,12 +95,8 @@ export interface UseMasonryReturn {
  * Headless masonry hook. Owns the virtualizer, lane-count tracking, and the SSR
  * fallback chain; returns prop bags you spread onto your own JSX.
  *
- * Selector contract emitted via the returned props:
- * - `[data-rvm-grid]` on the root, with `data-rvm-lanes="<n>"`
- * - `[data-rvm-item]` on each rendered item
- *
- * The grid root never declares `container-type`. For `@container` responsiveness,
- * wrap externally with your own `container-type: inline-size` element.
+ * Emits `[data-rvm-grid]` (with `data-rvm-lanes`) and `[data-rvm-item]` selectors.
+ * Never declares `container-type` — wrap externally for `@container`.
  */
 export function useMasonry<Data>({
   data,
@@ -114,33 +104,56 @@ export function useMasonry<Data>({
   estimateSize,
   overscan = DEFAULT_OVERSCAN,
   ssr,
+  scrollElementRef,
 }: UseMasonryOptions<Data>): UseMasonryReturn {
   // `getVirtualItems()` side-effects `measurementsCache` every render — auto-memo
   // would starve the SSR fallback slice.
   'use no memo';
 
   const gridRef = useRef<HTMLDivElement>(null);
+  const useContainer = !!scrollElementRef;
 
   // Clamp to >= 1 — lane math divides by n; 0/negative would emit Infinity/NaN CSS.
   const lanes = useCSSLaneCount(gridRef, {
     fallback: Math.max(1, ssr?.lanes ?? DEFAULT_LANES),
   });
 
-  const scrollMargin = useOffsetTop(gridRef, { fallback: ssr?.scrollMargin ?? 0 });
+  // Both offset hooks always run (rules-of-hooks); mode picks the active one.
+  // `ssr` is type-excluded in container mode, so the container fallback is 0.
+  const windowScrollMargin = useOffsetTop(gridRef, { fallback: ssr?.scrollMargin ?? 0 });
+  const containerScrollMargin = useContainerOffsetTop(gridRef, scrollElementRef, { fallback: 0 });
 
   // Explicit mount signal — reading `gridRef.current` during render is impure.
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
-  const virtualizer = useWindowVirtualizer({
+  // Rules-of-hooks forbids picking one virtualizer by mode, and their types are
+  // incompatible (`useVirtualizer` rejects `Window`). So both run; the idle one is
+  // made inert by TanStack's `enabled` option — no scroll/resize listeners.
+  const windowVirtualizer = useWindowVirtualizer({
     count: data.length,
     estimateSize: estimateSize ?? (() => 0),
     overscan,
     lanes,
-    scrollMargin,
+    scrollMargin: windowScrollMargin,
     gap: gutter,
     laneAssignmentMode: 'measured',
+    enabled: !useContainer,
   });
+
+  const elementVirtualizer = useVirtualizer({
+    count: data.length,
+    estimateSize: estimateSize ?? (() => 0),
+    overscan,
+    lanes,
+    scrollMargin: containerScrollMargin,
+    gap: gutter,
+    laneAssignmentMode: 'measured',
+    getScrollElement: () => scrollElementRef?.current ?? null,
+    enabled: useContainer,
+  });
+
+  const virtualizer = useContainer ? elementVirtualizer : windowVirtualizer;
 
   // Workaround: gap changes don't invalidate virtual-core's measurement cache.
   // https://github.com/TanStack/virtual/issues/1222


### PR DESCRIPTION
## Summary

Adds an optional `scrollElementRef` to `useMasonry`: pass a ref to an `overflow:auto` element and the grid windows against that element's scroll position instead of the page. 

Omitting it is byte-for-byte the current window-scroll behavior (control test).

### Design

TanStack ships two hooks (`useWindowVirtualizer`, `useVirtualizer`) and the latter's generic rejects `Window` at the type level, so you can't conditionally call one or the other (rules-of-hooks). 

Both run every render. TanStack's first-class `enabled` option makes the idle one inert (its `_willUpdate` short-circuits to no scroll/resize listeners — confirmed in virtual-core source). 

A new `useContainerOffsetTop` computes the container-relative `scrollMargin`.

### ADR

- Container mode is client-only: `scrollElementRef` and `ssr` are mutually exclusive at the type level (compile error if combined; a `@ts-expect-error` type test locks this in). Container-mode SSR is a documented follow-up.

- Ancestor layout shift: inside the container is not tracked (a fixed-height container has no resize signal for content growth above the grid). Documented constraint: keep content above the grid at a stable height (simplest: make the grid the container's first child). A MutationObserver fix is a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for virtualizing masonry layouts inside a custom scrollable container.
  * Documented and exposed a new scroll container option, with examples for both component and hook usage.
  * Added guidance for responsive lane counts when using container-based scrolling.

* **Bug Fixes**
  * Improved scrolling behavior so visible items are calculated correctly whether using the window or a custom container.
  * Clarified that container mode is client-only and can’t be combined with server-side rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->