### PR TITLE
fix: clamp out-of-range estimateSize probes

### DIFF
--- a/.changeset/estimate-size-clamp.md
+++ b/.changeset/estimate-size-clamp.md
@@ -1,0 +1,5 @@
+---
+'react-virtual-masonry': patch
+---
+
+Clamp out-of-range indices before invoking the consumer's `estimateSize`, so estimators like `(i) => data[i].height` no longer throw when the virtualizer transiently probes an index outside the data range.

--- a/package/src/hooks/useMasonry.estimateSize.test.tsx
+++ b/package/src/hooks/useMasonry.estimateSize.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useMasonry } from './useMasonry';
+
+// Capture the `estimateSize` the hook hands to TanStack so we can drive it with
+// the out-of-range indices the virtualizer transiently probes (mid-scrollToIndex,
+// or as a growing feed shrinks) and assert the hook clamps before the consumer's
+// estimator ever sees them.
+let capturedEstimateSize: ((index: number) => number) | undefined;
+
+vi.mock('@tanstack/react-virtual', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@tanstack/react-virtual')>();
+  return {
+    ...mod,
+    useWindowVirtualizer: ((options: Parameters<typeof mod.useWindowVirtualizer>[0]) => {
+      capturedEstimateSize = options.estimateSize;
+      return mod.useWindowVirtualizer(options);
+    }) as typeof mod.useWindowVirtualizer,
+  };
+});
+
+describe('useMasonry — estimateSize out-of-range clamp', () => {
+  it('clamps out-of-range indices to the nearest valid one before calling estimateSize', () => {
+    const data = [{ height: 100 }, { height: 200 }, { height: 300 }];
+    const estimateSize = vi.fn((i: number) => data[i].height);
+
+    renderHook(() => useMasonry({ data, estimateSize }));
+
+    expect(capturedEstimateSize).toBeDefined();
+    const bounded = capturedEstimateSize!;
+
+    // Below range → clamped to 0; above range → clamped to length - 1.
+    expect(bounded(-5)).toBe(100);
+    expect(bounded(0)).toBe(100);
+    expect(bounded(1)).toBe(200);
+    expect(bounded(2)).toBe(300);
+    expect(bounded(99)).toBe(300);
+
+    // The consumer's estimator only ever saw in-range indices — never threw.
+    for (const call of estimateSize.mock.calls) {
+      expect(call[0]).toBeGreaterThanOrEqual(0);
+      expect(call[0]).toBeLessThan(data.length);
+    }
+  });
+
+  it('does not crash when a throwing estimator is driven with out-of-range probes', () => {
+    const data = [{ height: 100 }, { height: 200 }];
+    // Throws on any out-of-range read, mirroring `(i) => data[i].height`.
+    const estimateSize = (i: number) => data[i].height;
+
+    renderHook(() => useMasonry({ data, estimateSize }));
+
+    expect(capturedEstimateSize).toBeDefined();
+    expect(() => capturedEstimateSize!(-1)).not.toThrow();
+    expect(() => capturedEstimateSize!(data.length + 10)).not.toThrow();
+  });
+
+  it('returns 0 for an empty data set instead of indexing into nothing', () => {
+    const data: { height: number }[] = [];
+    const estimateSize = (i: number) => data[i].height;
+
+    renderHook(() => useMasonry({ data, estimateSize }));
+
+    expect(capturedEstimateSize).toBeDefined();
+    expect(capturedEstimateSize!(0)).toBe(0);
+  });
+});

--- a/package/src/hooks/useMasonry.ts
+++ b/package/src/hooks/useMasonry.ts
@@ -127,12 +127,21 @@ export function useMasonry<Data>({
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
+  // The virtualizer transiently probes indices outside `data` (mid-`scrollToIndex`,
+  // or as a growing feed shrinks), so clamp to `[0, length-1]` before handing off to
+  // the consumer's `estimateSize` — otherwise estimators like `(i) => data[i].height`
+  // throw on the out-of-range read. Plain function is fine under `'use no memo'`.
+  const boundedEstimateSize = (index: number) => {
+    if (!estimateSize || data.length === 0) return 0;
+    return estimateSize(Math.min(Math.max(index, 0), data.length - 1));
+  };
+
   // Rules-of-hooks forbids picking one virtualizer by mode, and their types are
   // incompatible (`useVirtualizer` rejects `Window`). So both run; the idle one is
   // made inert by TanStack's `enabled` option — no scroll/resize listeners.
   const windowVirtualizer = useWindowVirtualizer({
     count: data.length,
-    estimateSize: estimateSize ?? (() => 0),
+    estimateSize: boundedEstimateSize,
     overscan,
     lanes,
     scrollMargin: windowScrollMargin,
@@ -143,7 +152,7 @@ export function useMasonry<Data>({
 
   const elementVirtualizer = useVirtualizer({
     count: data.length,
-    estimateSize: estimateSize ?? (() => 0),
+    estimateSize: boundedEstimateSize,
     overscan,
     lanes,
     scrollMargin: containerScrollMargin,


### PR DESCRIPTION
The virtualizer transiently probes indices outside `data` (mid-scrollToIndex, or as a growing feed shrinks), so a consumer estimator like `(i) => data[i].height` throws. Clamp the index to `[0, length-1]` before invoking the user's estimateSize.