### PR TITLE
feat: re-export the VirtualItem type

### DIFF
--- a/.changeset/reexport-virtual-item.md
+++ b/.changeset/reexport-virtual-item.md
@@ -1,0 +1,5 @@
+---
+'react-virtual-masonry': patch
+---
+
+Re-export the `VirtualItem` type from `@tanstack/react-virtual`, so consumers can type items from `useMasonry`/`getItemProps` directly instead of deriving `UseMasonryReturn['items'][number]`.

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -13,3 +13,5 @@ export type {
 
 export { useEndReached } from './hooks/useEndReached';
 export type { UseEndReachedOptions } from './hooks/useEndReached';
+
+export type { VirtualItem } from '@tanstack/react-virtual';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Re-exported the `VirtualItem` type so it can be imported directly from the package.
  * Simplified typing for masonry-related usage, making it easier to work with item props and virtualized items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->