### PR TITLE
feat: forward VirtualItem fields to renderItem

### DIFF
--- a/.changeset/render-item-virtual-item.md
+++ b/.changeset/render-item-virtual-item.md
@@ -1,0 +1,5 @@
+---
+'react-virtual-masonry': minor
+---
+
+`<Masonry>`'s `renderItem` callback now receives the full TanStack `VirtualItem` (`key`, `index`, `start`, `end`, `size`, `lane`) alongside the data `item`. This is additive — existing `({ item, index }) => ...` call sites keep working — and lets consumers read `lane` / `size` / `start` without dropping down to `useMasonry`.

--- a/docs/src/pages/docs/api/masonry.mdx
+++ b/docs/src/pages/docs/api/masonry.mdx
@@ -33,10 +33,12 @@ Items to lay out. Each entry is passed back to `renderItem` as `item`.
 
 ### renderItem
 
-- **Type:** `(props: { item: Data; index: number }) => ReactNode`
+- **Type:** `(props: VirtualItem & { item: Data }) => ReactNode`
 - **Required**
 
 Renders the content of a single item. The library wraps the result in an absolutely-positioned element it measures and places into a lane.
+
+Alongside the data element as `item`, the callback receives every field of the underlying TanStack `VirtualItem` — `key`, `index`, `start`, `end`, `size`, and `lane`. `index` maps into `data` exactly as before; the extras (notably `lane`, `size`, and `start`) previously forced consumers down to [`useMasonry`](/docs/api/use-masonry) just to read them.
 
 ### estimateSize
 

--- a/package/src/Masonry/index.test.tsx
+++ b/package/src/Masonry/index.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRef } from 'react';
 import { render } from '@testing-library/react';
+import type { VirtualItem } from '@tanstack/react-virtual';
 
 import { Masonry, type MasonryHandle } from './index';
 
@@ -24,6 +25,74 @@ describe('Masonry — imperative handle', () => {
     ref.current!.scrollToIndex(3, { align: 'center' });
 
     expect(spy).toHaveBeenCalledWith(3, { align: 'center' });
+  });
+});
+
+describe('Masonry — renderItem args', () => {
+  // Distinct values so we can prove `index` maps to the right data element.
+  const VALUES = [10, 20, 30, 40, 50, 60, 70, 80];
+
+  it('forwards the full VirtualItem fields alongside item', () => {
+    const seen: (VirtualItem & { item: number })[] = [];
+    render(
+      <Masonry
+        data={VALUES}
+        estimateSize={(i) => VALUES[i]}
+        renderItem={(props) => {
+          seen.push(props);
+          return <div>{props.index}</div>;
+        }}
+      />
+    );
+
+    expect(seen.length).toBeGreaterThan(0);
+    for (const props of seen) {
+      // VirtualItem fields are all present.
+      expect(props.key).toBeDefined();
+      expect(typeof props.index).toBe('number');
+      expect(typeof props.start).toBe('number');
+      expect(typeof props.end).toBe('number');
+      expect(typeof props.size).toBe('number');
+      expect(typeof props.lane).toBe('number');
+    }
+  });
+
+  it('keeps lane within [0, lanes-1] and index mapping to the right data element', () => {
+    // No `--lanes` stylesheet under happy-dom → falls back to DEFAULT_LANES (4).
+    const LANES = 4;
+    const seen: (VirtualItem & { item: number })[] = [];
+    render(
+      <Masonry
+        data={VALUES}
+        estimateSize={(i) => VALUES[i]}
+        renderItem={(props) => {
+          seen.push(props);
+          return <div>{props.index}</div>;
+        }}
+      />
+    );
+
+    for (const props of seen) {
+      expect(props.lane).toBeGreaterThanOrEqual(0);
+      expect(props.lane).toBeLessThanOrEqual(LANES - 1);
+      // `index` still points at the matching data element.
+      expect(props.item).toBe(VALUES[props.index]);
+    }
+  });
+
+  it('still supports the old ({ item, index }) destructuring shape', () => {
+    // Backwards compat: consumers written against the narrow prior signature keep working.
+    const { container } = render(
+      <Masonry
+        data={VALUES}
+        estimateSize={(i) => VALUES[i]}
+        renderItem={({ item, index }) => <div data-testid="cell">{`${index}:${item}`}</div>}
+      />
+    );
+    const cells = container.querySelectorAll('[data-testid="cell"]');
+    expect(cells.length).toBeGreaterThan(0);
+    // First cell reads `0:10` — index 0 mapped to VALUES[0].
+    expect(cells[0]?.textContent).toBe('0:10');
   });
 });
 

--- a/package/src/Masonry/index.tsx
+++ b/package/src/Masonry/index.tsx
@@ -6,7 +6,7 @@ import {
   Ref,
   useImperativeHandle,
 } from 'react';
-import type { ScrollToOptions, Virtualizer } from '@tanstack/react-virtual';
+import type { ScrollToOptions, VirtualItem, Virtualizer } from '@tanstack/react-virtual';
 
 import { useMasonry, type UseMasonryOptions } from '../hooks/useMasonry';
 import { useEndReached } from '../hooks/useEndReached';
@@ -28,7 +28,13 @@ export interface MasonryHandle {
 
 // `UseMasonryOptions` is a discriminated union — use intersection, not `extends`.
 type Props<Data> = UseMasonryOptions<Data> & {
-  renderItem: (props: { item: Data; index: number }) => ReactNode;
+  /** Renders one item. Receives the data element as `item`, plus every field of
+   *  the underlying TanStack {@link VirtualItem}: `key`, `index`, `start`, `end`,
+   *  `size`, and `lane`. `index` maps into `data` exactly as before. The extra
+   *  fields — notably `lane` (which column), `size` (measured/estimated height),
+   *  and `start` (offset within its lane) — previously forced consumers off
+   *  `<Masonry>` and down to {@link useMasonry} just to read them. */
+  renderItem: (props: VirtualItem & { item: Data }) => ReactNode;
   /** Instance-specific selector when multiple grids need different styling.
    *  Most usage can target `[data-rvm-grid]` and omit this. */
   className?: string;
@@ -63,9 +69,9 @@ function MasonryInner<Data>(props: Props<Data>, ref: Ref<MasonryHandle>) {
 
   return (
     <div {...gridProps} className={className} style={{ ...gridProps.style, ...style }}>
-      {items.map((item) => (
-        <div key={item.key} {...getItemProps(item)}>
-          {renderItem({ item: props.data[item.index], index: item.index })}
+      {items.map((virtualItem) => (
+        <div key={virtualItem.key} {...getItemProps(virtualItem)}>
+          {renderItem({ ...virtualItem, item: props.data[virtualItem.index] })}
         </div>
       ))}
     </div>


### PR DESCRIPTION
lane/size/start were previously hook-only, forcing consumers off <Masonry> just to read them. renderItem now receives the full VirtualItem (key, index, start, end, size, lane) alongside the data item. Additive: existing ({ item, index }) => ... call sites keep compiling.